### PR TITLE
[Feat] #3 식물 등록

### DIFF
--- a/planty/ios/Podfile.lock
+++ b/planty/ios/Podfile.lock
@@ -2,6 +2,8 @@ PODS:
   - Flutter (1.0.0)
   - flutter_secure_storage (6.0.0):
     - Flutter
+  - image_picker_ios (0.0.1):
+    - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -9,6 +11,7 @@ PODS:
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
+  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
 
 EXTERNAL SOURCES:
@@ -16,12 +19,15 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
+  image_picker_ios:
+    :path: ".symlinks/plugins/image_picker_ios/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
 
 PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5

--- a/planty/ios/Runner/Info.plist
+++ b/planty/ios/Runner/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>사진을 선택하기 위해 접근 권한이 필요합니다.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>사진을 촬영하기 위해 접근 권한이 필요합니다.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/planty/lib/constants/colors.dart
+++ b/planty/lib/constants/colors.dart
@@ -5,4 +5,5 @@ class AppColors {
   static Color light = Color(0xFFEEF3DB);
   static Color grey1 = Color(0xFFF5F5F5);
   static Color grey2 = Color(0xFFD9D9D9);
+  static Color grey3 = Color(0xFF7E7B7B);
 }

--- a/planty/lib/main.dart
+++ b/planty/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:planty/screens/home_screen.dart';
 import 'package:planty/screens/my_screen.dart';
+import 'package:planty/screens/plant_dictionary_screen.dart';
 import 'package:planty/screens/splash_screen.dart';
 
 void main() {
@@ -19,7 +20,7 @@ class MyApp extends StatelessWidget {
       routes: {
         '/splash': (context) => const SplashScreen(),
         '/home': (context) => const HomeScreen(),
-        '/plants': (context) => const HomeScreen(),
+        '/plants': (context) => const PlantDictionaryScreen(),
         '/chat': (context) => const HomeScreen(),
         '/my': (context) => const MyScreen(),
       },

--- a/planty/lib/models/iot_device.dart
+++ b/planty/lib/models/iot_device.dart
@@ -1,0 +1,22 @@
+class IotDevice {
+  final int id;
+  final String deviceSerial;
+  final String model;
+  final String status;
+
+  IotDevice({
+    required this.id,
+    required this.deviceSerial,
+    required this.model,
+    required this.status,
+  });
+
+  factory IotDevice.fromJson(Map<String, dynamic> json) {
+    return IotDevice(
+      id: json['id'],
+      deviceSerial: json['deviceSerial'],
+      model: json['model'],
+      status: json['status'],
+    );
+  }
+}

--- a/planty/lib/models/personality.dart
+++ b/planty/lib/models/personality.dart
@@ -1,0 +1,25 @@
+class Personality {
+  final int id;
+  final String label;
+  final String emoji;
+  final String description;
+  final String exampleComment;
+
+  Personality({
+    required this.id,
+    required this.label,
+    required this.emoji,
+    required this.description,
+    required this.exampleComment,
+  });
+
+  factory Personality.fromJson(Map<String, dynamic> json) {
+    return Personality(
+      id: json['id'],
+      label: json['label'],
+      emoji: json['emoji'],
+      description: json['description'],
+      exampleComment: json['exampleComment'],
+    );
+  }
+}

--- a/planty/lib/models/plant_info.dart
+++ b/planty/lib/models/plant_info.dart
@@ -13,7 +13,7 @@ class PlantInfo {
 
   factory PlantInfo.fromJson(Map<String, dynamic> json) {
     return PlantInfo(
-      id: json['id'] as int?,
+      id: json['plantInfoId'] as int,
       commonName: json['commonName'],
       englishName: json['englishName'],
       imageUrl: json['imageUrl'] as String?,

--- a/planty/lib/models/plant_info.dart
+++ b/planty/lib/models/plant_info.dart
@@ -1,0 +1,22 @@
+class PlantInfo {
+  final int? id;
+  final String commonName;
+  final String englishName;
+  final String? imageUrl;
+
+  PlantInfo({
+    required this.id,
+    required this.commonName,
+    required this.englishName,
+    required this.imageUrl,
+  });
+
+  factory PlantInfo.fromJson(Map<String, dynamic> json) {
+    return PlantInfo(
+      id: json['id'] as int?,
+      commonName: json['commonName'],
+      englishName: json['englishName'],
+      imageUrl: json['imageUrl'] as String?,
+    );
+  }
+}

--- a/planty/lib/models/plant_info_detail.dart
+++ b/planty/lib/models/plant_info_detail.dart
@@ -1,0 +1,143 @@
+class PlantInfoDetail {
+  final int? id;
+  final String? imageUrl;
+  final String? commonName;
+
+  // 기본 정보
+  final String? scientificName;
+  final String? englishName;
+  final String? tradeName;
+  final String? familyName;
+  final String? origin;
+  final String? careTip;
+
+  // 상세 정보
+  final String? category;
+  final String? growthForm;
+  final int? growthHeight;
+  final int? growthWidth;
+  final String? indoorGardenUse;
+  final String? ecologicalType;
+  final String? leafShape;
+  final String? leafPattern;
+  final String? leafColor;
+
+  final String? floweringSeason;
+  final String? flowerColor;
+  final String? fruitingSeason;
+  final String? fruitColor;
+  final String? fragrance;
+  final String? propagationMethod;
+  final String? propagationSeason;
+
+  // 관리 정보
+  final String? careLevel;
+  final String? careDifficulty;
+  final String? lightRequirement;
+  final String? placement;
+  final String? growthRate;
+  final String? optimalTemperature;
+  final String? minWinterTemperature;
+  final String? humidity;
+  final String? fertilizer;
+  final String? soilType;
+
+  final String? wateringSpring;
+  final String? wateringSummer;
+  final String? wateringAutumn;
+  final String? wateringWinter;
+  final String? pestsDiseases;
+
+  // 기능성 정보
+  final String? functionalInfo;
+
+  PlantInfoDetail({
+    this.id,
+    this.imageUrl,
+    this.commonName,
+    this.scientificName,
+    this.englishName,
+    this.tradeName,
+    this.familyName,
+    this.origin,
+    this.careTip,
+    this.category,
+    this.growthForm,
+    this.growthHeight,
+    this.growthWidth,
+    this.indoorGardenUse,
+    this.ecologicalType,
+    this.leafShape,
+    this.leafPattern,
+    this.leafColor,
+    this.floweringSeason,
+    this.flowerColor,
+    this.fruitingSeason,
+    this.fruitColor,
+    this.fragrance,
+    this.propagationMethod,
+    this.propagationSeason,
+    this.careLevel,
+    this.careDifficulty,
+    this.lightRequirement,
+    this.placement,
+    this.growthRate,
+    this.optimalTemperature,
+    this.minWinterTemperature,
+    this.humidity,
+    this.fertilizer,
+    this.soilType,
+    this.wateringSpring,
+    this.wateringSummer,
+    this.wateringAutumn,
+    this.wateringWinter,
+    this.pestsDiseases,
+    this.functionalInfo,
+  });
+
+  factory PlantInfoDetail.fromJson(Map<String, dynamic> json) {
+    return PlantInfoDetail(
+      id: json['id'],
+      imageUrl: json['imageUrl'],
+      commonName: json['commonName'],
+      scientificName: json['scientificName'],
+      englishName: json['englishName'],
+      tradeName: json['tradeName'],
+      familyName: json['familyName'],
+      origin: json['origin'],
+      careTip: json['careTip'],
+      category: json['category'],
+      growthForm: json['growthForm'],
+      growthHeight: json['growthHeight'],
+      growthWidth: json['growthWidth'],
+      indoorGardenUse: json['indoorGardenUse'],
+      ecologicalType: json['ecologicalType'],
+      leafShape: json['leafShape'],
+      leafPattern: json['leafPattern'],
+      leafColor: json['leafColor'],
+      floweringSeason: json['floweringSeason'],
+      flowerColor: json['flowerColor'],
+      fruitingSeason: json['fruitingSeason'],
+      fruitColor: json['fruitColor'],
+      fragrance: json['fragrance'],
+      propagationMethod: json['propagationMethod'],
+      propagationSeason: json['propagationSeason'],
+      careLevel: json['careLevel'],
+      careDifficulty: json['careDifficulty'],
+      lightRequirement: json['lightRequirement'],
+      placement: json['placement'],
+      growthRate: json['growthRate'],
+      optimalTemperature: json['optimalTemperature'],
+      minWinterTemperature: json['minWinterTemperature'],
+      humidity: json['humidity'],
+      fertilizer: json['fertilizer'],
+      soilType: json['soilType'],
+      wateringSpring: json['wateringSpring'],
+      wateringSummer: json['wateringSummer'],
+      wateringAutumn: json['wateringAutumn'],
+      wateringWinter: json['wateringWinter'],
+      pestsDiseases: json['pestsDiseases'],
+      functionalInfo: json['functionalInfo'],
+    );
+  }
+}

--- a/planty/lib/models/plant_info_detail.dart
+++ b/planty/lib/models/plant_info_detail.dart
@@ -140,4 +140,68 @@ class PlantInfoDetail {
       functionalInfo: json['functionalInfo'],
     );
   }
+
+  // 한글 매핑 메서드
+  // 기본 정보
+  Map<String, String?> toBasicInfoMap() {
+    return {
+      '학명': _formatValue(scientificName),
+      '영명': _formatValue(englishName),
+      '유통명': _formatValue(tradeName),
+      '원산지': _formatValue(origin),
+      'TIP': _formatValue(careTip),
+    };
+  }
+
+  // 상세 정보
+  Map<String, String?> toDetailInfoMap() {
+    return {
+      '분류': _formatValue(category),
+      '생육형태': _formatValue(growthForm),
+      '생장높이(cm)': _formatValue(growthHeight?.toString()),
+      '생장너비(cm)': _formatValue(growthWidth?.toString()),
+      '실내정원구성': _formatValue(indoorGardenUse),
+      '생태형': _formatValue(ecologicalType),
+      '잎형태': _formatValue(leafShape),
+      '잎무늬': _formatValue(leafPattern),
+      '잎색': _formatValue(leafColor),
+      '꽃피는 계절': _formatValue(floweringSeason),
+      '꽃색': _formatValue(flowerColor),
+      '열매맺는 계절': _formatValue(fruitingSeason),
+      '열매색': _formatValue(fruitColor),
+      '향기': _formatValue(fragrance),
+      '번식방법': _formatValue(propagationMethod),
+      '번식시기': _formatValue(propagationSeason),
+    };
+  }
+
+  // 관리 정보
+  Map<String, String?> toCareInfoMap() {
+    return {
+      '관리수준': _formatValue(careLevel),
+      '관리요구도': _formatValue(careDifficulty),
+      '광요구도': _formatValue(lightRequirement),
+      '배치장소': _formatValue(placement),
+      '생장속도': _formatValue(growthRate),
+      '생육적온': _formatValue(optimalTemperature),
+      '겨울최저온도': _formatValue(minWinterTemperature),
+      '습도': _formatValue(humidity),
+      '비료': _formatValue(fertilizer),
+      '토양': _formatValue(soilType),
+      '물주기-봄': _formatValue(wateringSpring),
+      '물주기-여름': _formatValue(wateringSummer),
+      '물주기-가을': _formatValue(wateringAutumn),
+      '물주기-겨울': _formatValue(wateringWinter),
+      '병충해': _formatValue(pestsDiseases),
+    };
+  }
+
+  // 기능성 정보
+  Map<String, String?> toFunctionInfoMap() {
+    return {'기능성 정보': functionalInfo};
+  }
+
+  String _formatValue(String? value) {
+    return value == null || value.trim().isEmpty ? '-' : value;
+  }
 }

--- a/planty/lib/models/register_plant.dart
+++ b/planty/lib/models/register_plant.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+
+class RegisterPlant {
+  final int plantId;
+  final String nickname;
+  final String adoptedDate;
+  final int personalityId;
+  final File? imageFile;
+
+  RegisterPlant({
+    required this.plantId,
+    required this.nickname,
+    required this.adoptedDate,
+    required this.personalityId,
+    this.imageFile,
+  });
+}

--- a/planty/lib/models/register_plant.dart
+++ b/planty/lib/models/register_plant.dart
@@ -6,6 +6,7 @@ class RegisterPlant {
   final String adoptedDate;
   final int personalityId;
   final File? imageFile;
+  final String imageUrl;
 
   RegisterPlant({
     required this.plantId,
@@ -13,5 +14,6 @@ class RegisterPlant {
     required this.adoptedDate,
     required this.personalityId,
     this.imageFile,
+    required this.imageUrl,
   });
 }

--- a/planty/lib/models/user_plant_summary_response.dart
+++ b/planty/lib/models/user_plant_summary_response.dart
@@ -3,7 +3,7 @@ class UserPlantSummaryResponse {
   final String nickname;
   final String imageUrl;
   final DateTime adoptedAt;
-  final Status status;
+  final Status? status;
   final Personality personality;
 
   UserPlantSummaryResponse({
@@ -21,7 +21,7 @@ class UserPlantSummaryResponse {
       nickname: json['nickname'],
       imageUrl: json['imageUrl'],
       adoptedAt: DateTime.parse(json['adoptedAt']),
-      status: Status.fromJson(json['status']),
+      status: json['status'] != null ? Status.fromJson(json['status']) : null,
       personality: Personality.fromJson(json['personality']),
     );
   }
@@ -42,10 +42,10 @@ class Status {
 
   factory Status.fromJson(Map<String, dynamic> json) {
     return Status(
-      temperatureScore: json['temperatureScore'],
-      lightScore: json['lightScore'],
-      humidityScore: json['humidityScore'],
-      message: json['message'].replaceAll(r'\\n', '\n'),
+      temperatureScore: json['temperatureScore'] ?? 0,
+      lightScore: json['lightScore'] ?? 0,
+      humidityScore: json['humidityScore'] ?? 0,
+      message: (json['message'] ?? '-').replaceAll(r'\\n', '\n'),
     );
   }
 }

--- a/planty/lib/screens/home_screen.dart
+++ b/planty/lib/screens/home_screen.dart
@@ -44,13 +44,7 @@ class _HomeScreenState extends State<HomeScreen> {
       // 상단바
       appBar: PreferredSize(
         preferredSize: Size.fromHeight(61),
-        child: CustomAppBar(
-          leading: Image.asset('assets/images/planty_logo.png', height: 30),
-          trailing: Icon(
-            Icons.notifications_outlined,
-            color: AppColors.primary,
-          ),
-        ),
+        child: CustomAppBar(trailingType: AppBarTrailingType.notification),
       ),
 
       // 바디

--- a/planty/lib/screens/home_screen.dart
+++ b/planty/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:planty/constants/colors.dart';
 import 'package:planty/models/user_plant_summary_response.dart';
+import 'package:planty/screens/register_plant/plant_list_screen.dart';
 import 'package:planty/services/user_plant_service.dart';
 import 'package:planty/widgets/custom_app_bar.dart';
 import 'package:planty/widgets/custom_bottom_nav_bar.dart';
@@ -89,36 +90,46 @@ class _HomeScreenState extends State<HomeScreen> {
                             ],
                           ),
                           // 식물 등록 버튼
-                          Container(
-                            decoration: BoxDecoration(
-                              border: Border.all(
-                                color: AppColors.primary,
-                                width: 0.5,
+                          GestureDetector(
+                            onTap: () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (context) => const PlantListScreen(),
+                                ),
+                              );
+                            },
+                            child: Container(
+                              decoration: BoxDecoration(
+                                border: Border.all(
+                                  color: AppColors.primary,
+                                  width: 0.5,
+                                ),
+                                borderRadius: BorderRadius.circular(15),
                               ),
-                              borderRadius: BorderRadius.circular(15),
-                            ),
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 10,
-                                vertical: 5,
-                              ),
-                              child: Row(
-                                children: [
-                                  Icon(
-                                    Icons.add_circle_rounded,
-                                    color: AppColors.primary,
-                                    size: 15,
-                                  ),
-                                  const SizedBox(width: 3),
-                                  Text(
-                                    '식물 등록',
-                                    style: TextStyle(
-                                      fontSize: 10,
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 10,
+                                  vertical: 5,
+                                ),
+                                child: Row(
+                                  children: [
+                                    Icon(
+                                      Icons.add_circle_rounded,
                                       color: AppColors.primary,
-                                      fontWeight: FontWeight.w600,
+                                      size: 15,
                                     ),
-                                  ),
-                                ],
+                                    const SizedBox(width: 3),
+                                    Text(
+                                      '식물 등록',
+                                      style: TextStyle(
+                                        fontSize: 10,
+                                        color: AppColors.primary,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ],
+                                ),
                               ),
                             ),
                           ),

--- a/planty/lib/screens/my_screen.dart
+++ b/planty/lib/screens/my_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:planty/constants/colors.dart';
 import 'package:planty/screens/login_screen.dart';
 import 'package:planty/widgets/custom_app_bar.dart';
 import 'package:planty/widgets/custom_bottom_nav_bar.dart';

--- a/planty/lib/screens/my_screen.dart
+++ b/planty/lib/screens/my_screen.dart
@@ -20,13 +20,7 @@ class _MyScreenState extends State<MyScreen> {
       // 상단바
       appBar: PreferredSize(
         preferredSize: Size.fromHeight(61),
-        child: CustomAppBar(
-          leading: Image.asset('assets/images/planty_logo.png', height: 30),
-          trailing: Icon(
-            Icons.notifications_outlined,
-            color: AppColors.primary,
-          ),
-        ),
+        child: CustomAppBar(trailingType: AppBarTrailingType.notification),
       ),
 
       // 바디

--- a/planty/lib/screens/plant_dictionary_screen.dart
+++ b/planty/lib/screens/plant_dictionary_screen.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:planty/models/plant_info.dart';
+import 'package:planty/services/plant_info_service.dart';
+import 'package:planty/widgets/custom_app_bar.dart';
+import 'package:planty/widgets/custom_bottom_nav_bar.dart';
+import 'package:planty/widgets/plant_info_card.dart';
+
+class PlantDictionaryScreen extends StatefulWidget {
+  const PlantDictionaryScreen({super.key});
+
+  @override
+  State<PlantDictionaryScreen> createState() => _PlantDictionaryScreenState();
+}
+
+class _PlantDictionaryScreenState extends State<PlantDictionaryScreen> {
+  List<PlantInfo> _plantsList = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchPlantList();
+  }
+
+  Future<void> _fetchPlantList() async {
+    try {
+      final plants = await PlantInfoService().fetchPlantLists();
+      setState(() {
+        _plantsList = plants;
+        _isLoading = false;
+      });
+    } catch (e) {
+      print('에러 발생: $e');
+      setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(61),
+        child: CustomAppBar(trailingType: AppBarTrailingType.notification),
+      ),
+      body: SafeArea(
+        child:
+            _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : _plantsList.isEmpty
+                ? const Center(child: Text('등록 가능한 식물이 없습니다.'))
+                : Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: ListView.builder(
+                    itemCount: _plantsList.length,
+                    itemBuilder: (context, index) {
+                      final plant = _plantsList[index];
+                      return GestureDetector(
+                        onTap: () {
+                          // Navigator.push(
+                          //   context,
+                          //   MaterialPageRoute(
+                          //     builder: (_) => PlantDetailScreen(plantId: plant.id),
+                          //   ),
+                          // );
+                        },
+                        child: PlantInfoCard(
+                          imageUrl: plant.imageUrl,
+                          commonName: plant.commonName,
+                          englishName: plant.englishName,
+                        ),
+                      );
+                    },
+                  ),
+                ),
+      ),
+      bottomNavigationBar: CustomBottomNavBar(currentIndex: 1, onTap: (_) {}),
+    );
+  }
+}

--- a/planty/lib/screens/register_plant/iot_device_select_screen.dart
+++ b/planty/lib/screens/register_plant/iot_device_select_screen.dart
@@ -164,6 +164,7 @@ class _IoTDeviceSelectScreenState extends State<IoTDeviceSelectScreen> {
               widget.data.nickname,
               widget.data.adoptedDate,
               widget.data.personalityId,
+              widget.data.imageUrl,
             );
 
             // 2. IoT 기기 연결

--- a/planty/lib/screens/register_plant/iot_device_select_screen.dart
+++ b/planty/lib/screens/register_plant/iot_device_select_screen.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:planty/constants/colors.dart';
+import 'package:planty/models/iot_device.dart';
+import 'package:planty/models/register_plant.dart';
+import 'package:planty/services/iot_device_service.dart';
+import 'package:planty/widgets/custom_app_bar.dart';
+import 'package:planty/widgets/primary_button.dart';
+import 'package:planty/widgets/register_bottom_bar.dart';
+
+class IoTDeviceSelectScreen extends StatefulWidget {
+  final RegisterPlant data;
+  const IoTDeviceSelectScreen({super.key, required this.data});
+
+  @override
+  State<IoTDeviceSelectScreen> createState() => _IoTDeviceSelectScreenState();
+}
+
+class _IoTDeviceSelectScreenState extends State<IoTDeviceSelectScreen> {
+  List<IotDevice> _iotDevices = [];
+  bool _isLoading = true;
+  int? _selectedDeviceId;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchDevices();
+  }
+
+  Future<void> _fetchDevices() async {
+    try {
+      final devices = await IotDeviceService().fetchUserIotDevices();
+      setState(() {
+        _iotDevices = devices;
+        _isLoading = false;
+      });
+    } catch (e) {
+      print('디바이스 불러오기 실패: $e');
+      setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(61),
+        child: CustomAppBar(
+          leadingType: AppBarLeadingType.back,
+          titleText: 'IoT 등록',
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              PrimaryButton(
+                onPressed: () {},
+                label: 'IoT 신규 등록',
+                height: 35,
+                fontSize: 12,
+              ),
+              Divider(
+                height: 16,
+                color: AppColors.primary.withOpacity(0.5),
+                thickness: 0.5,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                '연결할 IoT 디바이스 선택',
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.primary,
+                ),
+              ),
+              const SizedBox(height: 10),
+
+              _isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : _iotDevices.isEmpty
+                  ? const Text('사용 가능한 디바이스가 없습니다.')
+                  : ListView.builder(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    itemCount: _iotDevices.length,
+                    itemBuilder: (context, index) {
+                      final device = _iotDevices[index];
+                      final isSelected = device.id == _selectedDeviceId;
+
+                      return GestureDetector(
+                        onTap: () {
+                          setState(() {
+                            _selectedDeviceId = isSelected ? null : device.id;
+                          });
+                        },
+                        child: Container(
+                          margin: const EdgeInsets.symmetric(vertical: 6),
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: isSelected ? AppColors.light : Colors.white,
+                            border: Border.all(
+                              color:
+                                  isSelected
+                                      ? AppColors.primary
+                                      : AppColors.grey3,
+                            ),
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    '모델: ${device.model}',
+                                    style: const TextStyle(fontSize: 13),
+                                  ),
+                                  Text(
+                                    '일련번호: ${device.deviceSerial}',
+                                    style: const TextStyle(
+                                      fontSize: 11,
+                                      color: Colors.grey,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              Icon(
+                                isSelected
+                                    ? Icons.check_circle
+                                    : Icons.radio_button_unchecked,
+                                color:
+                                    isSelected
+                                        ? AppColors.primary
+                                        : Colors.grey,
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: RegisterBottomBar(
+        onPressed: () {
+          // TODO: 등록 로직 (API 호출)
+          print('선택된 deviceId: $_selectedDeviceId');
+        },
+      ),
+    );
+  }
+}

--- a/planty/lib/screens/register_plant/plant_detail_screen.dart
+++ b/planty/lib/screens/register_plant/plant_detail_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class PlantDetailScreen extends StatelessWidget {
+  const PlantDetailScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/planty/lib/screens/register_plant/plant_detail_screen.dart
+++ b/planty/lib/screens/register_plant/plant_detail_screen.dart
@@ -167,7 +167,11 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> {
               builder:
                   (_) => PlantInputScreen(
                     plantId: _plant!.id!,
-                    imageUrl: _plant!.imageUrl ?? '',
+                    imageUrl:
+                        _plant!.imageUrl?.isNotEmpty == true
+                            ? _plant!.imageUrl!
+                            : 'https://nongsaro.go.kr/cms_contents/301/12938_MF_ATTACH_01.jpg',
+
                     commonName: _plant!.commonName ?? '',
                     englishName: _plant!.englishName ?? '',
                   ),

--- a/planty/lib/screens/register_plant/plant_detail_screen.dart
+++ b/planty/lib/screens/register_plant/plant_detail_screen.dart
@@ -174,7 +174,13 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (_) => PlantInputScreen(plantId: _plant!.id!),
+                  builder:
+                      (_) => PlantInputScreen(
+                        plantId: _plant!.id!,
+                        imageUrl: _plant!.imageUrl ?? '',
+                        commonName: _plant!.commonName ?? '',
+                        englishName: _plant!.englishName ?? '',
+                      ),
                 ),
               );
             },

--- a/planty/lib/screens/register_plant/plant_detail_screen.dart
+++ b/planty/lib/screens/register_plant/plant_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:planty/models/plant_info_detail.dart';
 import 'package:planty/services/plant_info_service.dart';
 import 'package:planty/widgets/custom_app_bar.dart';
 import 'package:planty/widgets/detail_info_section.dart';
+import 'package:planty/widgets/primary_button.dart';
 
 class PlantDetailScreen extends StatefulWidget {
   final int? plantId;
@@ -156,6 +157,29 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> {
                     ],
                   ),
                 ),
+      ),
+      bottomNavigationBar: Container(
+        padding: const EdgeInsets.all(16),
+        height: 80,
+        decoration: BoxDecoration(
+          border: Border(top: BorderSide(color: AppColors.light, width: 1)),
+          color: Colors.white,
+        ),
+
+        child: Center(
+          child: PrimaryButton(
+            label: '등록하기',
+            onPressed: () => {},
+            width: 350,
+            height: 38,
+            fontSize: 13,
+            icon: const Icon(
+              Icons.add_circle_rounded,
+              color: Colors.white,
+              size: 16,
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/planty/lib/screens/register_plant/plant_detail_screen.dart
+++ b/planty/lib/screens/register_plant/plant_detail_screen.dart
@@ -1,10 +1,97 @@
 import 'package:flutter/material.dart';
+import 'package:planty/constants/colors.dart';
+import 'package:planty/models/plant_info_detail.dart';
+import 'package:planty/services/plant_info_service.dart';
+import 'package:planty/widgets/custom_app_bar.dart';
 
-class PlantDetailScreen extends StatelessWidget {
-  const PlantDetailScreen({super.key});
+class PlantDetailScreen extends StatefulWidget {
+  final int? plantId;
+
+  const PlantDetailScreen({super.key, required this.plantId});
+
+  @override
+  State<PlantDetailScreen> createState() => _PlantDetailScreenState();
+}
+
+class _PlantDetailScreenState extends State<PlantDetailScreen> {
+  PlantInfoDetail? _plant;
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchPlantDetail();
+  }
+
+  Future<void> _fetchPlantDetail() async {
+    try {
+      final plant = await PlantInfoService().fetchPlantDetail(
+        widget.plantId ?? 0,
+      );
+      setState(() {
+        _plant = plant;
+        _isLoading = false;
+      });
+    } catch (e) {
+      print('에러 발생: $e');
+      setState(() => _isLoading = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(61),
+        child: CustomAppBar(
+          leadingType: AppBarLeadingType.back,
+          titleText: '상세 정보',
+        ),
+      ),
+      body: SafeArea(
+        child:
+            _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : _plant == null
+                ? const Center(child: Text('식물 정보를 불러올 수 없습니다.'))
+                : SingleChildScrollView(
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Center(
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(12),
+                          child: Image.network(
+                            _plant!.imageUrl ??
+                                'https://nongsaro.go.kr/cms_contents/301/12938_MF_ATTACH_01.jpg',
+                            width: 200,
+                            height: 200,
+                            fit: BoxFit.cover,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                      Text(
+                        _plant!.commonName ?? '',
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                          color: AppColors.primary,
+                        ),
+                      ),
+                      Text(
+                        _plant!.englishName ?? '',
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: AppColors.primary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+      ),
+    );
   }
 }

--- a/planty/lib/screens/register_plant/plant_detail_screen.dart
+++ b/planty/lib/screens/register_plant/plant_detail_screen.dart
@@ -5,7 +5,7 @@ import 'package:planty/screens/register_plant/plant_input_screen.dart';
 import 'package:planty/services/plant_info_service.dart';
 import 'package:planty/widgets/custom_app_bar.dart';
 import 'package:planty/widgets/detail_info_section.dart';
-import 'package:planty/widgets/primary_button.dart';
+import 'package:planty/widgets/register_bottom_bar.dart';
 
 class PlantDetailScreen extends StatefulWidget {
   final int? plantId;
@@ -159,41 +159,21 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> {
                   ),
                 ),
       ),
-      bottomNavigationBar: Container(
-        padding: const EdgeInsets.all(16),
-        height: 80,
-        decoration: BoxDecoration(
-          border: Border(top: BorderSide(color: AppColors.light, width: 1)),
-          color: Colors.white,
-        ),
-
-        child: Center(
-          child: PrimaryButton(
-            label: '등록하기',
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder:
-                      (_) => PlantInputScreen(
-                        plantId: _plant!.id!,
-                        imageUrl: _plant!.imageUrl ?? '',
-                        commonName: _plant!.commonName ?? '',
-                        englishName: _plant!.englishName ?? '',
-                      ),
-                ),
-              );
-            },
-            width: 350,
-            height: 38,
-            fontSize: 13,
-            icon: const Icon(
-              Icons.add_circle_rounded,
-              color: Colors.white,
-              size: 16,
+      bottomNavigationBar: RegisterBottomBar(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder:
+                  (_) => PlantInputScreen(
+                    plantId: _plant!.id!,
+                    imageUrl: _plant!.imageUrl ?? '',
+                    commonName: _plant!.commonName ?? '',
+                    englishName: _plant!.englishName ?? '',
+                  ),
             ),
-          ),
-        ),
+          );
+        },
       ),
     );
   }

--- a/planty/lib/screens/register_plant/plant_detail_screen.dart
+++ b/planty/lib/screens/register_plant/plant_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:planty/constants/colors.dart';
 import 'package:planty/models/plant_info_detail.dart';
+import 'package:planty/screens/register_plant/plant_input_screen.dart';
 import 'package:planty/services/plant_info_service.dart';
 import 'package:planty/widgets/custom_app_bar.dart';
 import 'package:planty/widgets/detail_info_section.dart';
@@ -169,7 +170,14 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> {
         child: Center(
           child: PrimaryButton(
             label: '등록하기',
-            onPressed: () => {},
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => PlantInputScreen(plantId: _plant!.id!),
+                ),
+              );
+            },
             width: 350,
             height: 38,
             fontSize: 13,

--- a/planty/lib/screens/register_plant/plant_detail_screen.dart
+++ b/planty/lib/screens/register_plant/plant_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:planty/constants/colors.dart';
 import 'package:planty/models/plant_info_detail.dart';
 import 'package:planty/services/plant_info_service.dart';
 import 'package:planty/widgets/custom_app_bar.dart';
+import 'package:planty/widgets/detail_info_section.dart';
 
 class PlantDetailScreen extends StatefulWidget {
   final int? plantId;
@@ -60,33 +61,97 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      Container(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 5,
+                        ),
+                        decoration: BoxDecoration(color: Colors.white),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            // 식물 이미지
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(100),
+                              child: Image.network(
+                                _plant!.imageUrl ??
+                                    'https://nongsaro.go.kr/cms_contents/301/12938_MF_ATTACH_01.jpg',
+                                width: 100,
+                                height: 100,
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                            SizedBox(width: 20),
+                            // 식물 이름, 영문명
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    _plant!.commonName ?? '',
+                                    style: TextStyle(
+                                      color: AppColors.primary,
+                                      fontWeight: FontWeight.w600,
+                                      fontSize: 15,
+                                    ),
+                                  ),
+                                  Text(
+                                    _plant!.englishName ?? '',
+                                    style: TextStyle(
+                                      color: AppColors.primary,
+                                      fontSize: 11,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Divider(
+                        height: 16,
+                        color: AppColors.primary.withOpacity(0.5),
+                        thickness: 0.5,
+                      ),
+                      const SizedBox(height: 16),
                       Center(
                         child: ClipRRect(
                           borderRadius: BorderRadius.circular(12),
                           child: Image.network(
                             _plant!.imageUrl ??
                                 'https://nongsaro.go.kr/cms_contents/301/12938_MF_ATTACH_01.jpg',
-                            width: 200,
-                            height: 200,
+                            width: 300,
+                            height: 300,
                             fit: BoxFit.cover,
                           ),
                         ),
                       ),
-                      const SizedBox(height: 20),
-                      Text(
-                        _plant!.commonName ?? '',
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                          color: AppColors.primary,
-                        ),
+                      const SizedBox(height: 16),
+                      Divider(
+                        height: 16,
+                        color: AppColors.primary.withOpacity(0.5),
+                        thickness: 0.5,
                       ),
-                      Text(
-                        _plant!.englishName ?? '',
-                        style: TextStyle(
-                          fontSize: 14,
-                          color: AppColors.primary,
-                        ),
+                      SizedBox(height: 16),
+                      DetailInfoSection(
+                        title: '기본 정보',
+                        infoMap: _plant!.toBasicInfoMap(),
+                      ),
+
+                      DetailInfoSection(
+                        title: '상세 정보',
+                        infoMap: _plant!.toDetailInfoMap(),
+                      ),
+
+                      DetailInfoSection(
+                        title: '관리 정보',
+                        infoMap: _plant!.toCareInfoMap(),
+                      ),
+
+                      DetailInfoSection(
+                        title: '기능성 정보',
+                        infoMap: {'': _plant!.functionalInfo},
+                        showKey: false,
                       ),
                     ],
                   ),

--- a/planty/lib/screens/register_plant/plant_input_screen.dart
+++ b/planty/lib/screens/register_plant/plant_input_screen.dart
@@ -4,6 +4,8 @@ import 'package:image_picker/image_picker.dart';
 import 'package:intl/intl.dart';
 import 'package:planty/constants/colors.dart';
 import 'package:planty/models/personality.dart';
+import 'package:planty/models/register_plant.dart';
+import 'package:planty/screens/register_plant/iot_device_select_screen.dart';
 import 'package:planty/services/personality_service.dart';
 import 'package:planty/widgets/custom_app_bar.dart';
 import 'package:planty/widgets/register_bottom_bar.dart';
@@ -379,7 +381,33 @@ class _PlantInputScreenState extends State<PlantInputScreen> {
           ),
         ),
       ),
-      bottomNavigationBar: RegisterBottomBar(onPressed: () => {}),
+      bottomNavigationBar: RegisterBottomBar(
+        onPressed: () {
+          if (_nicknameController.text.isEmpty ||
+              _adoptedDateController.text.isEmpty ||
+              _selectedPersonalityId == null) {
+            ScaffoldMessenger.of(
+              context,
+            ).showSnackBar(SnackBar(content: Text('모든 정보를 입력해주세요.')));
+            return;
+          }
+
+          final data = RegisterPlant(
+            plantId: widget.plantId,
+            nickname: _nicknameController.text,
+            adoptedDate: _adoptedDateController.text,
+            personalityId: _selectedPersonalityId!,
+            imageFile: _imageFile,
+          );
+
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => IoTDeviceSelectScreen(data: data),
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/planty/lib/screens/register_plant/plant_input_screen.dart
+++ b/planty/lib/screens/register_plant/plant_input_screen.dart
@@ -90,7 +90,7 @@ class _PlantInputScreenState extends State<PlantInputScreen> {
     );
 
     if (pickedDate != null) {
-      String formatted = DateFormat('yyyy.MM.dd').format(pickedDate);
+      String formatted = DateFormat('yyyy-MM-dd').format(pickedDate);
       setState(() {
         _adoptedDateController.text = formatted;
       });

--- a/planty/lib/screens/register_plant/plant_input_screen.dart
+++ b/planty/lib/screens/register_plant/plant_input_screen.dart
@@ -1,12 +1,43 @@
+import 'dart:io';
+import 'dart:math';
+
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:planty/constants/colors.dart';
 import 'package:planty/widgets/custom_app_bar.dart';
 import 'package:planty/widgets/primary_button.dart';
 
-class PlantInputScreen extends StatelessWidget {
+class PlantInputScreen extends StatefulWidget {
   final int plantId;
+  final String imageUrl;
+  final String commonName;
+  final String englishName;
 
-  const PlantInputScreen({super.key, required this.plantId});
+  const PlantInputScreen({
+    super.key,
+    required this.plantId,
+    required this.imageUrl,
+    required this.commonName,
+    required this.englishName,
+  });
+
+  @override
+  State<PlantInputScreen> createState() => _PlantInputScreenState();
+}
+
+class _PlantInputScreenState extends State<PlantInputScreen> {
+  File? _imageFile;
+
+  Future<void> _pickImage() async {
+    final picker = ImagePicker();
+    final pickedFile = await picker.pickImage(source: ImageSource.gallery);
+
+    if (pickedFile != null) {
+      setState(() {
+        _imageFile = File(pickedFile.path);
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +50,109 @@ class PlantInputScreen extends StatelessWidget {
           titleText: '정보 입력',
         ),
       ),
-      body: Center(child: Text('선택한 plantId: $plantId')),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+                decoration: BoxDecoration(color: Colors.white),
+                // 상단 식물 정보
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    // 식물 이미지
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(100),
+                      child: Image.network(
+                        widget.imageUrl,
+                        width: 100,
+                        height: 100,
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                    SizedBox(width: 20),
+                    // 식물 이름, 영문명
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            widget.commonName,
+                            style: TextStyle(
+                              color: AppColors.primary,
+                              fontWeight: FontWeight.w600,
+                              fontSize: 15,
+                            ),
+                          ),
+                          Text(
+                            widget.englishName,
+                            style: TextStyle(
+                              color: AppColors.primary,
+                              fontSize: 11,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Divider(
+                height: 16,
+                color: AppColors.primary.withOpacity(0.5),
+                thickness: 0.5,
+              ),
+              const SizedBox(height: 16),
+
+              // 대표 이미지 선택
+              GestureDetector(
+                onTap: _pickImage,
+                child: Center(
+                  child: Container(
+                    width: 300,
+                    height: 300,
+                    decoration: BoxDecoration(
+                      color: AppColors.grey1,
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                    child:
+                        _imageFile != null
+                            ? ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: Image.file(_imageFile!, fit: BoxFit.cover),
+                            )
+                            : Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: const [
+                                Icon(
+                                  Icons.local_florist,
+                                  size: 40,
+                                  color: Colors.grey,
+                                ),
+                                SizedBox(height: 10),
+                                Text(
+                                  "대표 사진을 등록해주세요",
+                                  style: TextStyle(color: Colors.grey),
+                                ),
+                              ],
+                            ),
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: 16),
+              Divider(
+                height: 16,
+                color: AppColors.primary.withOpacity(0.5),
+                thickness: 0.5,
+              ),
+            ],
+          ),
+        ),
+      ),
       bottomNavigationBar: Container(
         padding: const EdgeInsets.all(16),
         height: 80,

--- a/planty/lib/screens/register_plant/plant_input_screen.dart
+++ b/planty/lib/screens/register_plant/plant_input_screen.dart
@@ -1,10 +1,10 @@
 import 'dart:io';
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:intl/intl.dart';
 import 'package:planty/constants/colors.dart';
 import 'package:planty/widgets/custom_app_bar.dart';
+import 'package:planty/widgets/custom_text_field.dart';
 import 'package:planty/widgets/primary_button.dart';
 
 class PlantInputScreen extends StatefulWidget {
@@ -27,6 +27,8 @@ class PlantInputScreen extends StatefulWidget {
 
 class _PlantInputScreenState extends State<PlantInputScreen> {
   File? _imageFile;
+  final TextEditingController _nicknameController = TextEditingController();
+  final TextEditingController _adoptedDateController = TextEditingController();
 
   Future<void> _pickImage() async {
     final picker = ImagePicker();
@@ -35,6 +37,37 @@ class _PlantInputScreenState extends State<PlantInputScreen> {
     if (pickedFile != null) {
       setState(() {
         _imageFile = File(pickedFile.path);
+      });
+    }
+  }
+
+  Future<void> _selectAdoptionDate() async {
+    DateTime? pickedDate = await showDatePicker(
+      context: context,
+      initialDate: DateTime.now(),
+      firstDate: DateTime(2000),
+      lastDate: DateTime.now(),
+      builder: (context, child) {
+        return Theme(
+          data: ThemeData(
+            colorScheme: ColorScheme.light(
+              primary: AppColors.primary,
+              onPrimary: Colors.white,
+              onSurface: AppColors.primary,
+            ),
+            textButtonTheme: TextButtonThemeData(
+              style: TextButton.styleFrom(foregroundColor: AppColors.primary),
+            ),
+          ),
+          child: child!,
+        );
+      },
+    );
+
+    if (pickedDate != null) {
+      String formatted = DateFormat('yyyy.MM.dd').format(pickedDate);
+      setState(() {
+        _adoptedDateController.text = formatted;
       });
     }
   }
@@ -142,12 +175,99 @@ class _PlantInputScreenState extends State<PlantInputScreen> {
                   ),
                 ),
               ),
-
               const SizedBox(height: 16),
               Divider(
                 height: 16,
                 color: AppColors.primary.withOpacity(0.5),
                 thickness: 0.5,
+              ),
+              const SizedBox(height: 16),
+
+              // 애칭
+              Text(
+                '애칭',
+                style: TextStyle(
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _nicknameController,
+                style: TextStyle(fontSize: 12),
+                decoration: InputDecoration(
+                  hintText: '애칭을 입력해주세요',
+                  hintStyle: TextStyle(color: AppColors.grey3, fontSize: 12),
+                  border: OutlineInputBorder(),
+
+                  // 포커스 안 됐을 때 테두리
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(10),
+                    borderSide: BorderSide(color: AppColors.grey3),
+                  ),
+
+                  // 포커스 됐을 때 테두리
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(10),
+                    borderSide: BorderSide(
+                      color: AppColors.primary,
+                      width: 1.5,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+
+              // 입양 날짜
+              Text(
+                '입양 날짜',
+                style: TextStyle(
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              TextFormField(
+                readOnly: true,
+                controller: _adoptedDateController,
+                onTap: _selectAdoptionDate,
+                style: TextStyle(fontSize: 12),
+                decoration: InputDecoration(
+                  hintText: 'YYYY.MM.DD',
+                  hintStyle: TextStyle(color: AppColors.grey3, fontSize: 12),
+                  suffixIcon: Icon(
+                    Icons.calendar_today,
+                    size: 16,
+                    color: AppColors.grey3,
+                  ),
+                  border: OutlineInputBorder(),
+
+                  // 포커스 안 됐을 때 테두리
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(10),
+                    borderSide: BorderSide(color: AppColors.grey3),
+                  ),
+
+                  // 포커스 됐을 때 테두리
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(10),
+                    borderSide: BorderSide(
+                      color: AppColors.primary,
+                      width: 1.5,
+                    ),
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: 16),
+
+              // 성격
+              Text(
+                '성격',
+                style: TextStyle(
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ],
           ),

--- a/planty/lib/screens/register_plant/plant_input_screen.dart
+++ b/planty/lib/screens/register_plant/plant_input_screen.dart
@@ -6,7 +6,7 @@ import 'package:planty/constants/colors.dart';
 import 'package:planty/models/personality.dart';
 import 'package:planty/services/personality_service.dart';
 import 'package:planty/widgets/custom_app_bar.dart';
-import 'package:planty/widgets/primary_button.dart';
+import 'package:planty/widgets/register_bottom_bar.dart';
 
 class PlantInputScreen extends StatefulWidget {
   final int plantId;
@@ -379,29 +379,7 @@ class _PlantInputScreenState extends State<PlantInputScreen> {
           ),
         ),
       ),
-      bottomNavigationBar: Container(
-        padding: const EdgeInsets.all(16),
-        height: 80,
-        decoration: BoxDecoration(
-          border: Border(top: BorderSide(color: AppColors.light, width: 1)),
-          color: Colors.white,
-        ),
-
-        child: Center(
-          child: PrimaryButton(
-            label: '등록하기',
-            onPressed: () => {},
-            width: 350,
-            height: 38,
-            fontSize: 13,
-            icon: const Icon(
-              Icons.add_circle_rounded,
-              color: Colors.white,
-              size: 16,
-            ),
-          ),
-        ),
-      ),
+      bottomNavigationBar: RegisterBottomBar(onPressed: () => {}),
     );
   }
 }

--- a/planty/lib/screens/register_plant/plant_input_screen.dart
+++ b/planty/lib/screens/register_plant/plant_input_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:planty/constants/colors.dart';
+import 'package:planty/widgets/custom_app_bar.dart';
+import 'package:planty/widgets/primary_button.dart';
+
+class PlantInputScreen extends StatelessWidget {
+  final int plantId;
+
+  const PlantInputScreen({super.key, required this.plantId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(61),
+        child: CustomAppBar(
+          leadingType: AppBarLeadingType.back,
+          titleText: '정보 입력',
+        ),
+      ),
+      body: Center(child: Text('선택한 plantId: $plantId')),
+      bottomNavigationBar: Container(
+        padding: const EdgeInsets.all(16),
+        height: 80,
+        decoration: BoxDecoration(
+          border: Border(top: BorderSide(color: AppColors.light, width: 1)),
+          color: Colors.white,
+        ),
+
+        child: Center(
+          child: PrimaryButton(
+            label: '등록하기',
+            onPressed: () => {},
+            width: 350,
+            height: 38,
+            fontSize: 13,
+            icon: const Icon(
+              Icons.add_circle_rounded,
+              color: Colors.white,
+              size: 16,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/planty/lib/screens/register_plant/plant_input_screen.dart
+++ b/planty/lib/screens/register_plant/plant_input_screen.dart
@@ -398,6 +398,7 @@ class _PlantInputScreenState extends State<PlantInputScreen> {
             adoptedDate: _adoptedDateController.text,
             personalityId: _selectedPersonalityId!,
             imageFile: _imageFile,
+            imageUrl: widget.imageUrl,
           );
 
           Navigator.push(

--- a/planty/lib/screens/register_plant/plant_list_screen.dart
+++ b/planty/lib/screens/register_plant/plant_list_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class PlantListScreen extends StatelessWidget {
+  const PlantListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/planty/lib/screens/register_plant/plant_list_screen.dart
+++ b/planty/lib/screens/register_plant/plant_list_screen.dart
@@ -1,10 +1,82 @@
 import 'package:flutter/material.dart';
+import 'package:planty/models/plant_info.dart';
+import 'package:planty/screens/register_plant/plant_detail_screen.dart';
+import 'package:planty/services/plant_info_service.dart';
+import 'package:planty/widgets/custom_app_bar.dart';
+import 'package:planty/widgets/plant_info_card.dart';
 
-class PlantListScreen extends StatelessWidget {
+class PlantListScreen extends StatefulWidget {
   const PlantListScreen({super.key});
 
   @override
+  State<PlantListScreen> createState() => _PlantListScreenState();
+}
+
+class _PlantListScreenState extends State<PlantListScreen> {
+  List<PlantInfo> _plantsList = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchPlantList();
+  }
+
+  Future<void> _fetchPlantList() async {
+    try {
+      final plants = await PlantInfoService().fetchPlantLists();
+      setState(() {
+        _plantsList = plants;
+        _isLoading = false;
+      });
+    } catch (e) {
+      print('에러 발생: $e');
+      setState(() => _isLoading = false);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(61),
+        child: CustomAppBar(
+          leadingType: AppBarLeadingType.back,
+          titleText: '식물 등록',
+        ),
+      ),
+      body: SafeArea(
+        child:
+            _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : _plantsList.isEmpty
+                ? const Center(child: Text('등록 가능한 식물이 없습니다.'))
+                : Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: ListView.builder(
+                    itemCount: _plantsList.length,
+                    itemBuilder: (context, index) {
+                      final plant = _plantsList[index];
+                      return GestureDetector(
+                        onTap: () {
+                          // Navigator.push(
+                          //   context,
+                          //   MaterialPageRoute(
+                          //     builder: (_) => PlantDetailScreen(plantId: plant.id),
+                          //   ),
+                          // );
+                        },
+                        child: PlantInfoCard(
+                          imageUrl: plant.imageUrl,
+                          commonName: plant.commonName,
+                          englishName: plant.englishName,
+                        ),
+                      );
+                    },
+                  ),
+                ),
+      ),
+    );
   }
 }

--- a/planty/lib/screens/register_plant/plant_list_screen.dart
+++ b/planty/lib/screens/register_plant/plant_list_screen.dart
@@ -60,12 +60,14 @@ class _PlantListScreenState extends State<PlantListScreen> {
                       final plant = _plantsList[index];
                       return GestureDetector(
                         onTap: () {
-                          // Navigator.push(
-                          //   context,
-                          //   MaterialPageRoute(
-                          //     builder: (_) => PlantDetailScreen(plantId: plant.id),
-                          //   ),
-                          // );
+                          print('눌린 식물 ID: ${plant.id}');
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder:
+                                  (_) => PlantDetailScreen(plantId: plant.id),
+                            ),
+                          );
                         },
                         child: PlantInfoCard(
                           imageUrl: plant.imageUrl,

--- a/planty/lib/screens/register_plant/register_complete_screen.dart
+++ b/planty/lib/screens/register_plant/register_complete_screen.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:planty/constants/colors.dart';
+import 'package:planty/screens/home_screen.dart';
+import 'package:planty/widgets/primary_button.dart';
+
+class RegisterCompleteScreen extends StatelessWidget {
+  final String nickname;
+
+  const RegisterCompleteScreen({super.key, required this.nickname});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.local_florist, color: AppColors.primary, size: 100),
+              const SizedBox(height: 24),
+              Text(
+                '$nickname 등록 완료!',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.primary,
+                ),
+              ),
+              const SizedBox(height: 8),
+              const Text(
+                '이제 홈에서 식물 상태를 확인할 수 있어요.',
+                style: TextStyle(fontSize: 13, color: Colors.black54),
+              ),
+              const SizedBox(height: 40),
+              PrimaryButton(
+                label: '홈으로 가기',
+                height: 38,
+                fontSize: 13,
+                onPressed: () {
+                  Navigator.pushAndRemoveUntil(
+                    context,
+                    MaterialPageRoute(builder: (_) => const HomeScreen()),
+                    (route) => false,
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/planty/lib/services/iot_device_service.dart
+++ b/planty/lib/services/iot_device_service.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:planty/models/iot_device.dart';
+import 'package:http/http.dart' as http;
+
+class IotDeviceService {
+  final _storage = FlutterSecureStorage();
+  final String _baseUrl = 'http://localhost:8080';
+
+  Future<List<IotDevice>> fetchUserIotDevices() async {
+    final token = await _storage.read(key: 'token');
+    if (token == null) throw Exception('토큰 없음');
+
+    final response = await http.get(
+      Uri.parse('$_baseUrl/iot-devices'),
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      final List data = jsonDecode(utf8.decode(response.bodyBytes));
+      return data.map((json) => IotDevice.fromJson(json)).toList();
+    } else {
+      throw Exception('IoT 디바이스 불러오기 실패');
+    }
+  }
+}

--- a/planty/lib/services/personality_service.dart
+++ b/planty/lib/services/personality_service.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+
+import 'package:planty/models/personality.dart';
+import 'package:http/http.dart' as http;
+
+class PersonalityService {
+  final String _baseUrl = 'http://localhost:8080';
+
+  Future<List<Personality>> fetchPersonalities() async {
+    final response = await http.get(Uri.parse('$_baseUrl/personalities'));
+
+    if (response.statusCode == 200) {
+      final List data = jsonDecode(utf8.decode(response.bodyBytes));
+      return data.map((json) => Personality.fromJson(json)).toList();
+    } else {
+      throw Exception('성격 불러오기 실패');
+    }
+  }
+}

--- a/planty/lib/services/plant_info_service.dart
+++ b/planty/lib/services/plant_info_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:planty/models/plant_info.dart';
 import 'package:http/http.dart' as http;
+import 'package:planty/models/plant_info_detail.dart';
 
 class PlantInfoService {
   final String _baseUrl = 'http://localhost:8080';
@@ -14,6 +15,19 @@ class PlantInfoService {
       return data.map((json) => PlantInfo.fromJson(json)).toList();
     } else {
       throw Exception('식물 리스트 불러오기 실패');
+    }
+  }
+
+  Future<PlantInfoDetail> fetchPlantDetail(int plantId) async {
+    final response = await http.get(Uri.parse('$_baseUrl/plants/$plantId'));
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> jsonData = json.decode(
+        utf8.decode(response.bodyBytes),
+      );
+      return PlantInfoDetail.fromJson(jsonData);
+    } else {
+      throw Exception('식물 상세 정보 불러오기 실패');
     }
   }
 }

--- a/planty/lib/services/plant_info_service.dart
+++ b/planty/lib/services/plant_info_service.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+
+import 'package:planty/models/plant_info.dart';
+import 'package:http/http.dart' as http;
+
+class PlantInfoService {
+  final String _baseUrl = 'http://localhost:8080';
+
+  Future<List<PlantInfo>> fetchPlantLists() async {
+    final response = await http.get(Uri.parse('$_baseUrl/plants'));
+
+    if (response.statusCode == 200) {
+      final List data = jsonDecode(utf8.decode(response.bodyBytes));
+      return data.map((json) => PlantInfo.fromJson(json)).toList();
+    } else {
+      throw Exception('식물 리스트 불러오기 실패');
+    }
+  }
+}

--- a/planty/lib/services/user_plant_service.dart
+++ b/planty/lib/services/user_plant_service.dart
@@ -27,4 +27,51 @@ class UserPlantService {
       throw Exception('식물 목록 불러오기 실패');
     }
   }
+
+  Future<int> registerUserPlant(
+    int plantId,
+    String nickname,
+    String adoptedDate,
+    int? personalityId,
+  ) async {
+    final token = await _storage.read(key: 'token');
+    if (token == null) throw Exception('토큰 없음');
+    final response = await http.post(
+      Uri.parse('$_baseUrl/user-plants'),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+      body: jsonEncode({
+        'plantInfoId': plantId,
+        'nickname': nickname,
+        'adoptedAt': adoptedDate,
+        'personalityId': personalityId,
+        'imageUrl': '',
+      }),
+    );
+
+    if (response.statusCode == 200) {
+      return int.parse(response.body); // userPlantId
+    } else {
+      throw Exception('반려식물 등록 실패');
+    }
+  }
+
+  Future<void> registerIotDevice(int userPlantId, int deviceId) async {
+    final token = await _storage.read(key: 'token');
+    if (token == null) throw Exception('토큰 없음');
+    final response = await http.post(
+      Uri.parse('$_baseUrl/user-plants/$userPlantId/device'),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+      body: jsonEncode({'iotDeviceId': deviceId}),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('IoT 기기 등록 실패');
+    }
+  }
 }

--- a/planty/lib/services/user_plant_service.dart
+++ b/planty/lib/services/user_plant_service.dart
@@ -33,6 +33,7 @@ class UserPlantService {
     String nickname,
     String adoptedDate,
     int? personalityId,
+    String imageUrl,
   ) async {
     final token = await _storage.read(key: 'token');
     if (token == null) throw Exception('토큰 없음');
@@ -47,7 +48,7 @@ class UserPlantService {
         'nickname': nickname,
         'adoptedAt': adoptedDate,
         'personalityId': personalityId,
-        'imageUrl': '',
+        'imageUrl': imageUrl,
       }),
     );
 

--- a/planty/lib/widgets/custom_app_bar.dart
+++ b/planty/lib/widgets/custom_app_bar.dart
@@ -1,15 +1,64 @@
 import 'package:flutter/material.dart';
 import 'package:planty/constants/colors.dart';
 
-class CustomAppBar extends StatelessWidget {
-  final Widget? leading; // 좌측 (로고 or 뒤로가기)
-  final Widget? center; // 중앙 (제목)
-  final Widget? trailing; // 우측 (알림 or 메뉴)
+enum AppBarLeadingType { none, back, logo }
 
-  const CustomAppBar({super.key, this.leading, this.center, this.trailing});
+enum AppBarTrailingType { none, notification, menu }
+
+class CustomAppBar extends StatelessWidget {
+  final AppBarLeadingType leadingType;
+  final String? titleText;
+  final AppBarTrailingType trailingType;
+
+  const CustomAppBar({
+    super.key,
+    this.leadingType = AppBarLeadingType.logo,
+    this.titleText,
+    this.trailingType = AppBarTrailingType.none,
+  });
 
   @override
   Widget build(BuildContext context) {
+    // 좌측 leading 처리
+    Widget leadingWidget;
+    switch (leadingType) {
+      case AppBarLeadingType.logo:
+        leadingWidget = Image.asset(
+          'assets/images/planty_logo.png',
+          height: 30,
+        );
+        break;
+      case AppBarLeadingType.back:
+        leadingWidget = IconButton(
+          onPressed: () => Navigator.pop(context),
+          icon: Icon(Icons.arrow_back_ios, color: AppColors.primary),
+        );
+        break;
+      case AppBarLeadingType.none:
+        leadingWidget = const SizedBox();
+        break;
+    }
+
+    // 우측 trailing 처리
+    Widget trailingWidget;
+    switch (trailingType) {
+      case AppBarTrailingType.notification:
+        trailingWidget = Icon(
+          Icons.notifications_outlined,
+          color: AppColors.primary,
+        );
+        break;
+      case AppBarTrailingType.menu:
+        trailingWidget = Icon(
+          Icons.more_vert_rounded,
+          color: AppColors.primary,
+        );
+        break;
+      case AppBarTrailingType.none:
+        trailingWidget = const SizedBox();
+        break;
+    }
+
     return SafeArea(
       child: Column(
         children: [
@@ -26,11 +75,25 @@ class CustomAppBar extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 // 좌측
-                SizedBox(width: 70, child: leading ?? const SizedBox()),
+                SizedBox(width: 70, child: leadingWidget),
                 // 중앙
-                Expanded(child: Center(child: center ?? const SizedBox())),
+                Expanded(
+                  child: Center(
+                    child:
+                        titleText != null
+                            ? Text(
+                              titleText!,
+                              style: TextStyle(
+                                color: AppColors.primary,
+                                fontWeight: FontWeight.w600,
+                                fontSize: 16,
+                              ),
+                            )
+                            : const SizedBox(),
+                  ),
+                ),
                 // 우측
-                SizedBox(width: 40, child: trailing ?? const SizedBox()),
+                SizedBox(width: 40, child: trailingWidget),
               ],
             ),
           ),

--- a/planty/lib/widgets/custom_bottom_nav_bar.dart
+++ b/planty/lib/widgets/custom_bottom_nav_bar.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:planty/constants/colors.dart';
+import 'package:planty/screens/home_screen.dart';
+import 'package:planty/screens/my_screen.dart';
+import 'package:planty/screens/plant_dictionary_screen.dart';
 
 class CustomBottomNavBar extends StatelessWidget {
   final int currentIndex;
@@ -39,12 +42,39 @@ class CustomBottomNavBar extends StatelessWidget {
   ) {
     final isSelected = currentIndex == index;
     return GestureDetector(
-      onTap: () => Navigator.pushReplacementNamed(context, routeName),
+      onTap: () {
+        if (!isSelected) {
+          Navigator.of(context).pushReplacement(
+            PageRouteBuilder(
+              pageBuilder:
+                  (context, animation, secondaryAnimation) =>
+                      _getScreenByRoute(routeName),
+              transitionDuration: Duration.zero,
+              reverseTransitionDuration: Duration.zero,
+            ),
+          );
+        }
+      },
       child: Icon(
         icon,
         color: isSelected ? AppColors.primary : AppColors.light,
         size: 28,
       ),
     );
+  }
+
+  Widget _getScreenByRoute(String routeName) {
+    switch (routeName) {
+      case '/home':
+        return const HomeScreen();
+      case '/plants':
+        return const PlantDictionaryScreen();
+      case '/chat':
+        return const HomeScreen();
+      case '/my':
+        return const MyScreen();
+      default:
+        return const HomeScreen();
+    }
   }
 }

--- a/planty/lib/widgets/detail_info_section.dart
+++ b/planty/lib/widgets/detail_info_section.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:planty/constants/colors.dart';
+
+class DetailInfoSection extends StatelessWidget {
+  final String title;
+  final Map<String, String?> infoMap;
+  final bool showKey;
+
+  const DetailInfoSection({
+    super.key,
+    required this.title,
+    required this.infoMap,
+    this.showKey = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // 제목
+        Text(
+          title,
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+            color: AppColors.primary,
+          ),
+        ),
+        const SizedBox(height: 13),
+
+        // 정보 카드
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: AppColors.light.withOpacity(0.5),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Column(
+            children:
+                infoMap.entries.map((entry) {
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 10),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (showKey)
+                          SizedBox(
+                            width: 90,
+                            child: Text(
+                              entry.key,
+                              style: TextStyle(
+                                fontWeight: FontWeight.w600,
+                                color: AppColors.primary,
+                                fontSize: 11,
+                              ),
+                            ),
+                          ),
+                        Expanded(
+                          child: Text(
+                            entry.value?.trim().isNotEmpty == true
+                                ? entry.value!
+                                : '-',
+                            style: TextStyle(
+                              fontSize: 11,
+                              color: AppColors.primary,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }).toList(),
+          ),
+        ),
+        SizedBox(height: 13),
+      ],
+    );
+  }
+}

--- a/planty/lib/widgets/plant_info_card.dart
+++ b/planty/lib/widgets/plant_info_card.dart
@@ -19,7 +19,10 @@ class PlantInfoCard extends StatelessWidget {
       padding: EdgeInsets.symmetric(horizontal: 20, vertical: 12),
       decoration: BoxDecoration(
         border: Border(
-          bottom: BorderSide(color: AppColors.primary, width: 0.5),
+          bottom: BorderSide(
+            color: AppColors.primary.withOpacity(0.5),
+            width: 0.5,
+          ),
         ),
         color: Colors.white,
       ),

--- a/planty/lib/widgets/plant_info_card.dart
+++ b/planty/lib/widgets/plant_info_card.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:planty/constants/colors.dart';
+
+class PlantInfoCard extends StatelessWidget {
+  final String? imageUrl;
+  final String commonName;
+  final String englishName;
+
+  const PlantInfoCard({
+    super.key,
+    required this.imageUrl,
+    required this.commonName,
+    required this.englishName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: AppColors.primary, width: 0.5),
+        ),
+        color: Colors.white,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          // 식물 이미지
+          ClipRRect(
+            borderRadius: BorderRadius.circular(100),
+            child: Image.network(
+              imageUrl ??
+                  "https://nongsaro.go.kr/cms_contents/301/12938_MF_ATTACH_01.jpg",
+              width: 50,
+              height: 50,
+              fit: BoxFit.cover,
+            ),
+          ),
+          SizedBox(width: 20),
+          // 식물 이름, 영문명
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  commonName,
+                  style: TextStyle(
+                    color: AppColors.primary,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 15,
+                  ),
+                ),
+                Text(
+                  englishName,
+                  style: TextStyle(color: AppColors.primary, fontSize: 11),
+                ),
+              ],
+            ),
+          ),
+          // 화살표
+          Container(
+            alignment: Alignment(1, 0),
+            width: 60,
+            child: Icon(
+              Icons.arrow_forward_ios,
+              color: AppColors.primary,
+              size: 19,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/planty/lib/widgets/primary_button.dart
+++ b/planty/lib/widgets/primary_button.dart
@@ -5,32 +5,50 @@ class PrimaryButton extends StatelessWidget {
   final VoidCallback onPressed;
   final String label;
   final bool isLoading;
+  final double width;
+  final double height;
+  final Widget? icon;
+  final double fontSize;
 
   const PrimaryButton({
     super.key,
     required this.onPressed,
     required this.label,
     this.isLoading = false,
+    this.width = double.infinity,
+    this.height = 50,
+    this.icon,
+    this.fontSize = 15,
   });
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: double.infinity,
-      height: 50,
+      width: width,
+      height: height,
       child: ElevatedButton(
         onPressed: isLoading ? null : onPressed,
-        style: ElevatedButton.styleFrom(backgroundColor: AppColors.primary),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.primary,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+        ),
         child:
             isLoading
                 ? const CircularProgressIndicator(color: Colors.white)
-                : Text(
-                  label,
-                  style: TextStyle(
-                    fontSize: 15,
-                    color: Colors.white,
-                    fontWeight: FontWeight.w600,
-                  ),
+                : Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (icon != null) ...[icon!, const SizedBox(width: 6)],
+                    Text(
+                      label,
+                      style: TextStyle(
+                        fontSize: fontSize,
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
                 ),
       ),
     );

--- a/planty/lib/widgets/register_bottom_bar.dart
+++ b/planty/lib/widgets/register_bottom_bar.dart
@@ -24,21 +24,23 @@ class RegisterBottomBar extends StatelessWidget {
       size: 16,
     );
 
-    return Container(
-      padding: const EdgeInsets.all(16),
-      height: 80,
-      decoration: BoxDecoration(
-        border: Border(top: BorderSide(color: AppColors.light, width: 1)),
-        color: Colors.white,
-      ),
-      child: Center(
-        child: PrimaryButton(
-          label: label,
-          onPressed: onPressed,
-          width: 350,
-          height: 38,
-          fontSize: 13,
-          icon: showIcon ? (icon ?? defaultIcon) : null,
+    return SafeArea(
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        height: 70,
+        decoration: BoxDecoration(
+          border: Border(top: BorderSide(color: AppColors.light, width: 1)),
+          color: Colors.white,
+        ),
+        child: Center(
+          child: PrimaryButton(
+            label: label,
+            onPressed: onPressed,
+            width: 350,
+            height: 38,
+            fontSize: 13,
+            icon: showIcon ? (icon ?? defaultIcon) : null,
+          ),
         ),
       ),
     );

--- a/planty/lib/widgets/register_bottom_bar.dart
+++ b/planty/lib/widgets/register_bottom_bar.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:planty/constants/colors.dart';
+import 'package:planty/widgets/primary_button.dart';
+
+class RegisterBottomBar extends StatelessWidget {
+  final VoidCallback onPressed;
+  final String label;
+  final Widget? icon;
+  final bool showIcon;
+
+  const RegisterBottomBar({
+    super.key,
+    required this.onPressed,
+    this.label = '등록하기',
+    this.icon,
+    this.showIcon = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final defaultIcon = const Icon(
+      Icons.add_circle_rounded,
+      color: Colors.white,
+      size: 16,
+    );
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      height: 80,
+      decoration: BoxDecoration(
+        border: Border(top: BorderSide(color: AppColors.light, width: 1)),
+        color: Colors.white,
+      ),
+      child: Center(
+        child: PrimaryButton(
+          label: label,
+          onPressed: onPressed,
+          width: 350,
+          height: 38,
+          fontSize: 13,
+          icon: showIcon ? (icon ?? defaultIcon) : null,
+        ),
+      ),
+    );
+  }
+}

--- a/planty/lib/widgets/user_plant_card.dart
+++ b/planty/lib/widgets/user_plant_card.dart
@@ -10,6 +10,8 @@ class UserPlantCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final status = plant.status;
+
     return Container(
       margin: EdgeInsets.symmetric(vertical: 12, horizontal: 16),
       padding: EdgeInsets.all(16),
@@ -97,19 +99,19 @@ class UserPlantCard extends StatelessWidget {
                             PlantStatusBtn(
                               icon: Icons.thermostat_rounded,
                               iconColor: AppColors.grey2,
-                              score: plant.status.temperatureScore,
+                              score: status?.temperatureScore ?? 0,
                             ),
                             SizedBox(width: 15),
                             PlantStatusBtn(
                               icon: Icons.wb_sunny_rounded,
                               iconColor: AppColors.grey2,
-                              score: plant.status.lightScore,
+                              score: status?.lightScore ?? 0,
                             ),
                             SizedBox(width: 15),
                             PlantStatusBtn(
                               icon: Icons.water_drop_rounded,
                               iconColor: AppColors.grey2,
-                              score: plant.status.humidityScore,
+                              score: status?.humidityScore ?? 0,
                             ),
                           ],
                         ),
@@ -130,7 +132,7 @@ class UserPlantCard extends StatelessWidget {
                 child: Padding(
                   padding: EdgeInsets.symmetric(vertical: 10, horizontal: 15),
                   child: Text(
-                    plant.status.message,
+                    status?.message ?? '-',
                     style: TextStyle(fontSize: 13),
                     textAlign: TextAlign.center,
                   ),

--- a/planty/linux/flutter/generated_plugin_registrant.cc
+++ b/planty/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);

--- a/planty/linux/flutter/generated_plugins.cmake
+++ b/planty/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
   flutter_secure_storage_linux
 )
 

--- a/planty/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/planty/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import file_selector_macos
 import flutter_secure_storage_macos
 import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/planty/pubspec.lock
+++ b/planty/pubspec.lock
@@ -264,6 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.1"
   js:
     dependency: transitive
     description:

--- a/planty/pubspec.lock
+++ b/planty/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -65,6 +73,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+2"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -78,6 +118,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.28"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -152,6 +200,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "317a5d961cec5b34e777b9252393f2afbd23084aa6e60fcf601dcf6341b9ebeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+23"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "34a65f6740df08bbbeb0a1abd8e6d32107941fd4868f67a507b25601651022c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   js:
     dependency: transitive
     description:
@@ -216,6 +328,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:

--- a/planty/pubspec.yaml
+++ b/planty/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   http: ^1.3.0
   flutter_secure_storage: ^9.2.4
   image_picker: ^1.1.2
+  intl: ^0.18.1
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8

--- a/planty/pubspec.yaml
+++ b/planty/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     sdk: flutter
   http: ^1.3.0
   flutter_secure_storage: ^9.2.4
+  image_picker: ^1.1.2
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8

--- a/planty/windows/flutter/generated_plugin_registrant.cc
+++ b/planty/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
 }

--- a/planty/windows/flutter/generated_plugins.cmake
+++ b/planty/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_windows
   flutter_secure_storage_windows
 )
 


### PR DESCRIPTION
### Pull Request
식물 등록 flow 구현

**🪾작업한 브랜치**
- feat/# 3-register-plant

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-FE/issues/3
- https://github.com/Team-BIoTy/Planty-BE/issues/4

**🔥 작업 내용**

- 반려식물 등록 Flow 전체 구현
1. 홈 화면 → 등록 버튼 클릭 시 등록 플로우 진입
2. 식물 도감 목록 페이지 구현 (GET /plants 연동 + PlantInfoCard 위젯)
3. 도감 상세 정보 페이지 구현 (GET /plants/{plantId} 연동 + DetailInfoSection 위젯)
4. 사용자 입력 화면 구성 (애칭, 입양일, 성격 선택 UI 및 데이터 바인딩)
5. IoT 기기 목록 조회 및 선택 화면 구성 (GET /iot-devices)
6. 반려식물 등록 API 호출 (POST /user-plants), IoT 기기 연결 (POST /user-plants/{id}/device)
7. 등록 완료 후 완료 페이지 이동 처리

|등록 flow|
|--|
|<img src="https://github.com/user-attachments/assets/b0ae00d0-c726-47e6-a507-5d1453b3c5fa" width="250">|

- 상단바 구조 개선 → 좌측/중앙/우측 enum으로 역할 분리 및 기본값 지정
- 홈 화면 오류 수정 → 상태(status) 값 없는 식물도 정상 렌더링되도록 예외 처리

**🎨 화면 상세**

|기능|화면|
|--|--|
|식물 도감 목록|<img width="200px" src="https://github.com/user-attachments/assets/ce29e18c-316b-460c-99bc-89c7957be77d" />|
|식물 상세 정보|<img width="180" src="https://github.com/user-attachments/assets/20d1ce75-13d4-4451-af73-c4ee954b5f39" /> <img width="180" src="https://github.com/user-attachments/assets/00ad7a14-1ffd-48c8-aa91-9b0245cbc2e6" /> <img width="180" src="https://github.com/user-attachments/assets/d95ed970-b341-4069-86df-98b4cf04ce4f" />|
|사용자 입력(사진,애칭,입양일,성격)|<img width="180" src="https://github.com/user-attachments/assets/df2ae417-f594-4c36-957a-1a3274ae77d8" /> <img width="180"  src="https://github.com/user-attachments/assets/928c083c-f683-45e3-83f1-cb5d72c3ed98" /> <img width="180" src="https://github.com/user-attachments/assets/f3719b11-977e-46e1-8734-ee4465588661" />|
|IoT 기기 목록 조회 및 선택|<img width="200px" src="https://github.com/user-attachments/assets/553a7063-ad86-4031-a1b9-56509584f66c" />|
|등록 완료|<img width="200px" src="https://github.com/user-attachments/assets/7f7e821b-9784-4fcb-9343-9e922ad6c0ee" /> <img width="200px" src="https://github.com/user-attachments/assets/a0574c83-553d-4b2f-8731-914548805e36" />|









**🚀 추후 개발**
1. 이미지 관련 이슈 해결
- 기본 이미지 수정 (현재는 가울테리아 이미지)
- 사용자가 등록한 이미지는 File, 현재 이미지 컬럼은 String -> 포맷 통일화 및 이미지 등록 플로우 개선 필요

2. IoT 기기 목록
- 다른 식물에 등록된 여부 표시 필요
- 현재 다른 식물에 등록된 IoT 기기 선택 후 등록하기 버튼 누르면 오류나고 IoT_deviece_id 없이 user_plant 가 생성됨 !!오류해결필요!!

3. IoT 신규 등록
- 구현 필요
