### PR TITLE
[Feat] #4 반려식물 상세 리포트

### DIFF
--- a/planty/lib/models/env_standard.dart
+++ b/planty/lib/models/env_standard.dart
@@ -1,0 +1,30 @@
+class EnvStandard {
+  final Range temperature;
+  final Range light;
+  final Range humidity;
+
+  EnvStandard({
+    required this.temperature,
+    required this.light,
+    required this.humidity,
+  });
+
+  factory EnvStandard.fromJson(Map<String, dynamic> json) {
+    return EnvStandard(
+      temperature: Range.fromJson(json['temperature']),
+      light: Range.fromJson(json['light']),
+      humidity: Range.fromJson(json['humidity']),
+    );
+  }
+}
+
+class Range {
+  final int min;
+  final int max;
+
+  Range({required this.min, required this.max});
+
+  factory Range.fromJson(Map<String, dynamic> json) {
+    return Range(min: json['min'], max: json['max']);
+  }
+}

--- a/planty/lib/models/personality.dart
+++ b/planty/lib/models/personality.dart
@@ -2,6 +2,7 @@ class Personality {
   final int id;
   final String label;
   final String emoji;
+  final String color;
   final String description;
   final String exampleComment;
 
@@ -9,6 +10,7 @@ class Personality {
     required this.id,
     required this.label,
     required this.emoji,
+    required this.color,
     required this.description,
     required this.exampleComment,
   });
@@ -18,6 +20,7 @@ class Personality {
       id: json['id'],
       label: json['label'],
       emoji: json['emoji'],
+      color: json['color'] ?? '#FFFFFF',
       description: json['description'],
       exampleComment: json['exampleComment'],
     );

--- a/planty/lib/models/sensor_data.dart
+++ b/planty/lib/models/sensor_data.dart
@@ -1,0 +1,22 @@
+class SensorData {
+  final double temperature;
+  final double humidity;
+  final double light;
+  final DateTime recordedAt;
+
+  SensorData({
+    required this.temperature,
+    required this.humidity,
+    required this.light,
+    required this.recordedAt,
+  });
+
+  factory SensorData.fromJson(Map<String, dynamic> json) {
+    return SensorData(
+      temperature: (json['temperature'] as num).toDouble(),
+      humidity: (json['humidity'] as num).toDouble(),
+      light: (json['light'] as num).toDouble(),
+      recordedAt: DateTime.parse(json['recordedAt']),
+    );
+  }
+}

--- a/planty/lib/models/user_plant_detail_response.dart
+++ b/planty/lib/models/user_plant_detail_response.dart
@@ -1,0 +1,49 @@
+import 'package:planty/models/env_standard.dart';
+import 'package:planty/models/personality.dart';
+import 'package:planty/models/plant_info_detail.dart';
+import 'package:planty/models/sensor_data.dart';
+import 'package:planty/models/user_plant_status.dart';
+
+class UserPlantDetailResponse {
+  final int id;
+  final String nickname;
+  final String imageUrl;
+  final DateTime adoptedAt;
+  final Personality personality;
+  final PlantInfoDetail plantInfo;
+  final EnvStandard envStandard;
+  final UserPlantStatus? status;
+  final SensorData? sensorData;
+
+  UserPlantDetailResponse({
+    required this.id,
+    required this.nickname,
+    required this.imageUrl,
+    required this.adoptedAt,
+    required this.personality,
+    required this.plantInfo,
+    required this.envStandard,
+    this.status,
+    this.sensorData,
+  });
+
+  factory UserPlantDetailResponse.fromJson(Map<String, dynamic> json) {
+    return UserPlantDetailResponse(
+      id: json['id'],
+      nickname: json['nickname'],
+      imageUrl: json['imageUrl'],
+      adoptedAt: DateTime.parse(json['adoptedAt']),
+      personality: Personality.fromJson(json['personality']),
+      plantInfo: PlantInfoDetail.fromJson(json['plantInfo']),
+      envStandard: EnvStandard.fromJson(json['envStandard']),
+      status:
+          json['status'] != null
+              ? UserPlantStatus.fromJson(json['status'])
+              : null,
+      sensorData:
+          json['sensorData'] != null
+              ? SensorData.fromJson(json['sensorData'])
+              : null,
+    );
+  }
+}

--- a/planty/lib/models/user_plant_status.dart
+++ b/planty/lib/models/user_plant_status.dart
@@ -1,0 +1,25 @@
+class UserPlantStatus {
+  final int temperatureScore;
+  final int lightScore;
+  final int humidityScore;
+  final String statusMessage;
+  final DateTime checkedAt;
+
+  UserPlantStatus({
+    required this.temperatureScore,
+    required this.lightScore,
+    required this.humidityScore,
+    required this.statusMessage,
+    required this.checkedAt,
+  });
+
+  factory UserPlantStatus.fromJson(Map<String, dynamic> json) {
+    return UserPlantStatus(
+      temperatureScore: json['temperatureScore'],
+      lightScore: json['lightScore'],
+      humidityScore: json['humidityScore'],
+      statusMessage: json['statusMessage'],
+      checkedAt: DateTime.parse(json['checkedAt']),
+    );
+  }
+}

--- a/planty/lib/screens/home_screen.dart
+++ b/planty/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:planty/constants/colors.dart';
 import 'package:planty/models/user_plant_summary_response.dart';
 import 'package:planty/screens/register_plant/plant_list_screen.dart';
+import 'package:planty/screens/user_plant_detail_screen.dart';
 import 'package:planty/services/user_plant_service.dart';
 import 'package:planty/widgets/custom_app_bar.dart';
 import 'package:planty/widgets/custom_bottom_nav_bar.dart';
@@ -148,7 +149,22 @@ class _HomeScreenState extends State<HomeScreen> {
                         ),
                       )
                     else
-                      ..._plants.map((plant) => UserPlantCard(plant: plant)),
+                      ..._plants.map(
+                        (plant) => UserPlantCard(
+                          plant: plant,
+                          onTap: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder:
+                                    (context) => UserPlantDetailScreen(
+                                      userPlantId: plant.userPlantId,
+                                    ),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
                   ],
                 ),
       ),

--- a/planty/lib/screens/user_plant_detail_screen.dart
+++ b/planty/lib/screens/user_plant_detail_screen.dart
@@ -1,0 +1,351 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:planty/constants/colors.dart';
+import 'package:planty/models/user_plant_detail_response.dart';
+import 'package:planty/services/user_plant_service.dart';
+import 'package:planty/widgets/custom_app_bar.dart';
+import 'package:planty/widgets/detail_info_section.dart';
+import 'package:planty/widgets/env_card.dart';
+import 'package:planty/widgets/primary_button.dart';
+
+class UserPlantDetailScreen extends StatefulWidget {
+  final int userPlantId;
+
+  const UserPlantDetailScreen({super.key, required this.userPlantId});
+
+  @override
+  State<UserPlantDetailScreen> createState() => _UserPlantDetailScreenState();
+}
+
+class _UserPlantDetailScreenState extends State<UserPlantDetailScreen> {
+  bool _isLoading = true;
+  UserPlantDetailResponse? _plantDetail;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchDeatil();
+  }
+
+  Future<void> _fetchDeatil() async {
+    try {
+      final detail = await UserPlantService().fetchUserPlantDetail(
+        widget.userPlantId,
+      );
+      setState(() {
+        _plantDetail = detail;
+        _isLoading = false;
+      });
+    } catch (e) {
+      print('에러 발생: $e');
+      setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    String formatRange(int? min, int? max, {String unit = ''}) {
+      if (min == null || max == null) return '-';
+      return '$min$unit ~ $max$unit';
+    }
+
+    String formatValue(dynamic value, {String unit = ''}) {
+      if (value == null) return '-';
+      return '${value.round()}$unit'; // int형으로 처리
+    }
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(61),
+        child: CustomAppBar(
+          leadingType: AppBarLeadingType.back,
+          titleText: "상세 리포트",
+          trailingType: AppBarTrailingType.menu,
+        ),
+      ),
+      body:
+          _isLoading
+              ? const Center(child: CircularProgressIndicator())
+              : _plantDetail == null
+              ? const Center(child: Text("정보를 불러올 수 없습니다."))
+              : SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 1. 식물 카드
+                    Container(
+                      decoration: BoxDecoration(
+                        color: AppColors.light.withOpacity(0.5),
+                        borderRadius: BorderRadius.circular(15),
+                      ),
+                      padding: const EdgeInsets.all(25),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Stack(
+                            children: [
+                              // 식물 이미지
+                              ClipRRect(
+                                borderRadius: BorderRadius.circular(100),
+                                child: Image.network(
+                                  _plantDetail!.imageUrl,
+                                  width: 150,
+                                  height: 150,
+                                  fit: BoxFit.cover,
+                                ),
+                              ),
+                              // 이모티콘
+                              Positioned(
+                                bottom: 0,
+                                left: 0,
+                                child: Container(
+                                  width: 40,
+                                  height: 40,
+                                  decoration: BoxDecoration(
+                                    color: _hexToColor(
+                                      _plantDetail!.personality.color,
+                                    ),
+                                    shape: BoxShape.circle,
+                                  ),
+                                  child: Center(
+                                    child: Text(
+                                      _plantDetail!.personality.emoji,
+                                      style: TextStyle(fontSize: 20),
+                                      textAlign: TextAlign.center,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+
+                          SizedBox(width: 20),
+
+                          // 정보 + 버튼
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                // 닉네임
+                                Text(
+                                  _plantDetail!.nickname,
+                                  style: TextStyle(
+                                    color: AppColors.primary,
+                                    fontSize: 20,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                // 식물명
+                                Text(
+                                  _plantDetail!.plantInfo.commonName ?? "-",
+                                  style: TextStyle(
+                                    color: AppColors.grey3,
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                // 영문명
+                                Text(
+                                  _plantDetail!.plantInfo.scientificName ?? "",
+                                  style: TextStyle(
+                                    color: AppColors.grey3,
+                                    fontSize: 11,
+                                  ),
+                                ),
+
+                                const SizedBox(height: 5),
+                                Divider(
+                                  height: 16,
+                                  color: AppColors.primary.withOpacity(0.5),
+                                  thickness: 0.5,
+                                ),
+                                const SizedBox(height: 5),
+
+                                // 날짜
+                                Text(
+                                  '함께 한 지 ${DateTime.now().difference(_plantDetail!.adoptedAt).inDays}일째',
+                                  style: TextStyle(
+                                    color: AppColors.primary,
+                                    fontSize: 14,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+
+                                // 챗봇 버튼
+                                PrimaryButton(
+                                  onPressed: () => {},
+                                  label: "테리와 대화하기",
+                                  width: 110,
+                                  height: 33,
+                                  fontSize: 11,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    SizedBox(height: 20),
+
+                    // 2. 실시간 환경
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Text(
+                              "실시간 환경",
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                                color: AppColors.primary,
+                              ),
+                            ),
+                            Text(
+                              _plantDetail?.sensorData?.recordedAt != null
+                                  ? DateFormat(
+                                    'MM월 dd일 HH:mm 업데이트',
+                                  ).format(_plantDetail!.sensorData!.recordedAt)
+                                  : "정보 없음",
+                              style: TextStyle(
+                                fontSize: 8,
+                                color: AppColors.primary,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 13),
+
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            EnvCard(
+                              icon: Icons.thermostat,
+                              label: '환경 온도',
+                              value: formatValue(
+                                _plantDetail?.sensorData?.temperature,
+                                unit: '°C',
+                              ),
+                              recommendedLabel: '권장 온도',
+                              recommendedValue: formatRange(
+                                _plantDetail?.envStandard.temperature.min,
+                                _plantDetail?.envStandard.temperature.max,
+                                unit: '°C',
+                              ),
+                              averageLabel: '평균 온도',
+                              averageValue: formatValue(
+                                _plantDetail?.status?.temperatureScore,
+                                unit: '°C',
+                              ),
+                            ),
+                            EnvCard(
+                              icon: Icons.wb_sunny_outlined,
+                              label: '환경 조도',
+                              value: formatValue(
+                                _plantDetail?.sensorData?.light,
+                                unit: 'Lux',
+                              ),
+                              recommendedLabel: '권장 조도',
+                              recommendedValue: formatRange(
+                                _plantDetail?.envStandard.light.min,
+                                _plantDetail?.envStandard.light.max,
+                                unit: 'Lux',
+                              ),
+                              averageLabel: '평균 조도',
+                              averageValue: formatValue(
+                                _plantDetail?.status?.lightScore,
+                                unit: 'Lux',
+                              ),
+                            ),
+                            EnvCard(
+                              icon: Icons.water_drop,
+                              label: '흙 수분',
+                              value: formatValue(
+                                _plantDetail?.sensorData?.humidity,
+                                unit: '%',
+                              ),
+                              recommendedLabel: '권장 수분',
+                              recommendedValue: formatRange(
+                                _plantDetail?.envStandard.humidity.min,
+                                _plantDetail?.envStandard.humidity.max,
+                                unit: '%',
+                              ),
+                              averageLabel: '평균 수분',
+                              averageValue: formatValue(
+                                _plantDetail?.status?.humidityScore,
+                                unit: '%',
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 13),
+                      ],
+                    ),
+
+                    const SizedBox(height: 5),
+                    Divider(
+                      height: 16,
+                      color: AppColors.primary.withOpacity(0.5),
+                      thickness: 0.5,
+                    ),
+                    const SizedBox(height: 5),
+
+                    // 3. 식물 도감
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // 제목
+                        Text(
+                          "식물 도감",
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.primary,
+                          ),
+                        ),
+                        const SizedBox(height: 13),
+                        DetailInfoSection(
+                          title: '기본 정보',
+                          size: 12,
+                          infoMap: _plantDetail!.plantInfo.toBasicInfoMap(),
+                        ),
+
+                        DetailInfoSection(
+                          title: '상세 정보',
+                          size: 12,
+                          infoMap: _plantDetail!.plantInfo.toDetailInfoMap(),
+                        ),
+
+                        DetailInfoSection(
+                          title: '관리 정보',
+                          size: 12,
+                          infoMap: _plantDetail!.plantInfo.toCareInfoMap(),
+                        ),
+
+                        DetailInfoSection(
+                          title: '기능성 정보',
+                          size: 12,
+                          infoMap: {'': _plantDetail!.plantInfo.functionalInfo},
+                          showKey: false,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+    );
+  }
+}
+
+Color _hexToColor(String hex) {
+  hex = hex.replaceAll('#', '');
+  if (hex.length == 6) {
+    hex = 'FF$hex'; // 불투명도 100% (alpha)
+  }
+  return Color(int.parse(hex, radix: 16));
+}

--- a/planty/lib/services/user_plant_service.dart
+++ b/planty/lib/services/user_plant_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:planty/models/user_plant_detail_response.dart';
 import 'package:planty/models/user_plant_summary_response.dart';
 import 'package:http/http.dart' as http;
 
@@ -8,6 +9,7 @@ class UserPlantService {
   final _storage = FlutterSecureStorage();
   final _baseUrl = 'http://localhost:8080';
 
+  // 사용자의 반려 식물 목록 불러오기 - 홈화면
   Future<List<UserPlantSummaryResponse>> fetchUserPlants() async {
     final token = await _storage.read(key: 'token');
     if (token == null) throw Exception('토큰 없음');
@@ -28,6 +30,28 @@ class UserPlantService {
     }
   }
 
+  // 사용자 반려 식물 상세 리포트
+  Future<UserPlantDetailResponse> fetchUserPlantDetail(int userPlantId) async {
+    final token = await _storage.read(key: 'token');
+    if (token == null) throw Exception('토큰 없음');
+
+    final response = await http.get(
+      Uri.parse('$_baseUrl/user-plants/$userPlantId'),
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(utf8.decode(response.bodyBytes));
+      return UserPlantDetailResponse.fromJson(data);
+    } else {
+      throw Exception('반려식물 상세 정보 조회 실패');
+    }
+  }
+
+  // 사용자 반려 식물 등록
   Future<int> registerUserPlant(
     int plantId,
     String nickname,
@@ -59,6 +83,7 @@ class UserPlantService {
     }
   }
 
+  // 반려식물에 IoT 기기 연결
   Future<void> registerIotDevice(int userPlantId, int deviceId) async {
     final token = await _storage.read(key: 'token');
     if (token == null) throw Exception('토큰 없음');

--- a/planty/lib/widgets/detail_info_section.dart
+++ b/planty/lib/widgets/detail_info_section.dart
@@ -5,12 +5,14 @@ class DetailInfoSection extends StatelessWidget {
   final String title;
   final Map<String, String?> infoMap;
   final bool showKey;
+  final double size;
 
   const DetailInfoSection({
     super.key,
     required this.title,
     required this.infoMap,
     this.showKey = true,
+    this.size = 16,
   });
 
   @override
@@ -22,7 +24,7 @@ class DetailInfoSection extends StatelessWidget {
         Text(
           title,
           style: TextStyle(
-            fontSize: 16,
+            fontSize: size,
             fontWeight: FontWeight.w600,
             color: AppColors.primary,
           ),

--- a/planty/lib/widgets/env_card.dart
+++ b/planty/lib/widgets/env_card.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:planty/constants/colors.dart';
+
+class EnvCard extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final String recommendedLabel;
+  final String recommendedValue;
+  final String averageLabel;
+  final String averageValue;
+
+  const EnvCard({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.recommendedLabel,
+    required this.recommendedValue,
+    required this.averageLabel,
+    required this.averageValue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 4),
+        padding: const EdgeInsets.all(6),
+        decoration: BoxDecoration(
+          color: AppColors.light.withOpacity(0.5),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 50,
+                  height: 50,
+                  decoration: const BoxDecoration(
+                    color: Colors.white,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Center(
+                    child: Icon(icon, color: AppColors.primary, size: 25),
+                  ),
+                ),
+                const SizedBox(width: 5),
+                Column(
+                  children: [
+                    Text(
+                      label,
+                      style: TextStyle(fontSize: 8, color: AppColors.primary),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      value,
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.primary,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Text(
+                  recommendedLabel,
+                  style: TextStyle(
+                    fontSize: 7,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.primary,
+                  ),
+                ),
+                const SizedBox(width: 3),
+                Text(
+                  recommendedValue,
+                  style: TextStyle(fontSize: 7, color: AppColors.primary),
+                ),
+              ],
+            ),
+            Row(
+              children: [
+                Text(
+                  averageLabel,
+                  style: TextStyle(
+                    fontSize: 7,
+                    fontWeight: FontWeight.bold,
+                    color: AppColors.primary,
+                  ),
+                ),
+                const SizedBox(width: 3),
+                Text(
+                  averageValue,
+                  style: TextStyle(fontSize: 7, color: AppColors.primary),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/planty/lib/widgets/user_plant_card.dart
+++ b/planty/lib/widgets/user_plant_card.dart
@@ -5,142 +5,146 @@ import 'package:planty/widgets/plant_status_btn.dart';
 
 class UserPlantCard extends StatelessWidget {
   final UserPlantSummaryResponse plant;
+  final VoidCallback? onTap;
 
-  const UserPlantCard({super.key, required this.plant});
+  const UserPlantCard({super.key, required this.plant, this.onTap});
 
   @override
   Widget build(BuildContext context) {
     final status = plant.status;
 
-    return Container(
-      margin: EdgeInsets.symmetric(vertical: 12, horizontal: 16),
-      padding: EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        border: Border.all(color: AppColors.primary.withOpacity(0.5)),
-        borderRadius: BorderRadius.circular(20),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Column(
-            children: [
-              // 상단 Row: 식물 이미지, 이모티콘 + 닉네임, 날짜 + 상태 버튼
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // 식물 이미지 + 이모티콘
-                  Stack(
-                    children: [
-                      // 식물 이미지
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(100),
-                        child: Image.network(
-                          plant.imageUrl,
-                          width: 127,
-                          height: 127,
-                          fit: BoxFit.cover,
-                        ),
-                      ),
-                      // 이모티콘
-                      Positioned(
-                        bottom: 0,
-                        left: 0,
-                        child: Container(
-                          width: 40,
-                          height: 40,
-                          decoration: BoxDecoration(
-                            color: _hexToColor(plant.personality.color),
-                            shape: BoxShape.circle,
-                          ),
-                          child: Center(
-                            child: Text(
-                              plant.personality.emoji,
-                              style: TextStyle(fontSize: 20),
-                              textAlign: TextAlign.center,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-
-                  SizedBox(width: 15),
-
-                  // 닉네임, 날짜 + 상태 버튼
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        margin: EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+        padding: EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          border: Border.all(color: AppColors.primary.withOpacity(0.5)),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Column(
+              children: [
+                // 상단 Row: 식물 이미지, 이모티콘 + 닉네임, 날짜 + 상태 버튼
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 식물 이미지 + 이모티콘
+                    Stack(
                       children: [
-                        // 닉네임
-                        Text(
-                          plant.nickname,
-                          style: TextStyle(
-                            color: AppColors.primary,
-                            fontSize: 16,
-                            fontWeight: FontWeight.w600,
+                        // 식물 이미지
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(100),
+                          child: Image.network(
+                            plant.imageUrl,
+                            width: 127,
+                            height: 127,
+                            fit: BoxFit.cover,
                           ),
                         ),
-                        // 날짜
-                        Text(
-                          '함께 한 지 ${DateTime.now().difference(plant.adoptedAt).inDays}일째',
-                          style: TextStyle(
-                            color: AppColors.primary,
-                            fontSize: 10,
-                            fontWeight: FontWeight.w600,
+                        // 이모티콘
+                        Positioned(
+                          bottom: 0,
+                          left: 0,
+                          child: Container(
+                            width: 40,
+                            height: 40,
+                            decoration: BoxDecoration(
+                              color: _hexToColor(plant.personality.color),
+                              shape: BoxShape.circle,
+                            ),
+                            child: Center(
+                              child: Text(
+                                plant.personality.emoji,
+                                style: TextStyle(fontSize: 20),
+                                textAlign: TextAlign.center,
+                              ),
+                            ),
                           ),
-                        ),
-
-                        SizedBox(height: 15),
-
-                        // 식물 인터랙션 버튼 + 상태 하트
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.start,
-                          children: [
-                            PlantStatusBtn(
-                              icon: Icons.thermostat_rounded,
-                              iconColor: AppColors.grey2,
-                              score: status?.temperatureScore ?? 0,
-                            ),
-                            SizedBox(width: 15),
-                            PlantStatusBtn(
-                              icon: Icons.wb_sunny_rounded,
-                              iconColor: AppColors.grey2,
-                              score: status?.lightScore ?? 0,
-                            ),
-                            SizedBox(width: 15),
-                            PlantStatusBtn(
-                              icon: Icons.water_drop_rounded,
-                              iconColor: AppColors.grey2,
-                              score: status?.humidityScore ?? 0,
-                            ),
-                          ],
                         ),
                       ],
                     ),
-                  ),
-                ],
-              ),
-              SizedBox(height: 10),
 
-              // 상태 메시지
-              Container(
-                width: double.infinity,
-                decoration: BoxDecoration(
-                  color: AppColors.light.withOpacity(0.5),
-                  borderRadius: BorderRadius.circular(20),
+                    SizedBox(width: 15),
+
+                    // 닉네임, 날짜 + 상태 버튼
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          // 닉네임
+                          Text(
+                            plant.nickname,
+                            style: TextStyle(
+                              color: AppColors.primary,
+                              fontSize: 16,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          // 날짜
+                          Text(
+                            '함께 한 지 ${DateTime.now().difference(plant.adoptedAt).inDays}일째',
+                            style: TextStyle(
+                              color: AppColors.primary,
+                              fontSize: 10,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+
+                          SizedBox(height: 15),
+
+                          // 식물 인터랙션 버튼 + 상태 하트
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.start,
+                            children: [
+                              PlantStatusBtn(
+                                icon: Icons.thermostat_rounded,
+                                iconColor: AppColors.grey2,
+                                score: status?.temperatureScore ?? 0,
+                              ),
+                              SizedBox(width: 15),
+                              PlantStatusBtn(
+                                icon: Icons.wb_sunny_rounded,
+                                iconColor: AppColors.grey2,
+                                score: status?.lightScore ?? 0,
+                              ),
+                              SizedBox(width: 15),
+                              PlantStatusBtn(
+                                icon: Icons.water_drop_rounded,
+                                iconColor: AppColors.grey2,
+                                score: status?.humidityScore ?? 0,
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
-                child: Padding(
-                  padding: EdgeInsets.symmetric(vertical: 10, horizontal: 15),
-                  child: Text(
-                    status?.message ?? '-',
-                    style: TextStyle(fontSize: 13),
-                    textAlign: TextAlign.center,
+                SizedBox(height: 10),
+
+                // 상태 메시지
+                Container(
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    color: AppColors.light.withOpacity(0.5),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(vertical: 10, horizontal: 15),
+                    child: Text(
+                      status?.message ?? '-',
+                      style: TextStyle(fontSize: 13),
+                      textAlign: TextAlign.center,
+                    ),
                   ),
                 ),
-              ),
-            ],
-          ),
-        ],
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
### Pull Request
반려식물 상세 리포트 구현

**🪾작업한 브랜치**
- feat/# 4-user-plant-detail

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-FE/issues/4
- https://github.com/Team-BIoTy/Planty-BE/issues/5

**🔥 작업 내용**
- 반려식물 상세 페이지 관련 모델 추가 (EnvStandard, SensorData, UserPlantStatus)
- Personality 모델에 color 필드 추가
- UserPlantDetailResponse 응답 모델 정의
- 홈 화면 반려식물 카드 onTap 클릭 이벤트 → 상세 페이지 이동 연결
- 반려식물 상세 리포트 조회 API 연동
- 반려식물 상세 리포트 UI 구현

|기능|화면|
|--|--|
|홈에서 반려식물 카드 클릭 시 이동|<img src="https://github.com/user-attachments/assets/b0660bd7-7460-4b52-8874-d06fc614f78b" width="250px">|