### PR TITLE
[Fix]#15 상세리포트 접근 오류 & 채팅방 터치 영역 확장

### DIFF
--- a/planty/lib/models/env_standard.dart
+++ b/planty/lib/models/env_standard.dart
@@ -1,19 +1,21 @@
 class EnvStandard {
-  final Range temperature;
-  final Range light;
-  final Range humidity;
+  final Range? temperature;
+  final Range? light;
+  final Range? humidity;
 
-  EnvStandard({
-    required this.temperature,
-    required this.light,
-    required this.humidity,
-  });
+  EnvStandard({this.temperature, this.light, this.humidity});
 
-  factory EnvStandard.fromJson(Map<String, dynamic> json) {
+  factory EnvStandard.fromJson(Map<String, dynamic>? json) {
+    if (json == null) return EnvStandard();
+
     return EnvStandard(
-      temperature: Range.fromJson(json['temperature']),
-      light: Range.fromJson(json['light']),
-      humidity: Range.fromJson(json['humidity']),
+      temperature:
+          json['temperature'] != null
+              ? Range.fromJson(json['temperature'])
+              : null,
+      light: json['light'] != null ? Range.fromJson(json['light']) : null,
+      humidity:
+          json['humidity'] != null ? Range.fromJson(json['humidity']) : null,
     );
   }
 }
@@ -25,6 +27,6 @@ class Range {
   Range({required this.min, required this.max});
 
   factory Range.fromJson(Map<String, dynamic> json) {
-    return Range(min: json['min'], max: json['max']);
+    return Range(min: json['min'] ?? 0, max: json['max'] ?? 0);
   }
 }

--- a/planty/lib/screens/chat/chat_list_screen.dart
+++ b/planty/lib/screens/chat/chat_list_screen.dart
@@ -170,7 +170,7 @@ class _ChatListScreenState extends State<ChatListScreen> with RouteAware {
                           final chat = _chatRooms[index];
                           return Padding(
                             padding: const EdgeInsets.symmetric(vertical: 8),
-                            child: GestureDetector(
+                            child: InkWell(
                               onTap: () {
                                 Navigator.push(
                                   context,

--- a/planty/lib/screens/home/user_plant_detail_screen.dart
+++ b/planty/lib/screens/home/user_plant_detail_screen.dart
@@ -233,8 +233,8 @@ class _UserPlantDetailScreenState extends State<UserPlantDetailScreen> {
                               ),
                               recommendedLabel: '권장 온도',
                               recommendedValue: formatRange(
-                                _plantDetail?.envStandard.temperature.min,
-                                _plantDetail?.envStandard.temperature.max,
+                                _plantDetail?.envStandard.temperature?.min,
+                                _plantDetail?.envStandard.temperature?.max,
                                 unit: '°C',
                               ),
                               averageLabel: '평균 온도',
@@ -252,8 +252,8 @@ class _UserPlantDetailScreenState extends State<UserPlantDetailScreen> {
                               ),
                               recommendedLabel: '권장 조도',
                               recommendedValue: formatRange(
-                                _plantDetail?.envStandard.light.min,
-                                _plantDetail?.envStandard.light.max,
+                                _plantDetail?.envStandard.light?.min,
+                                _plantDetail?.envStandard.light?.max,
                                 unit: 'Lux',
                               ),
                               averageLabel: '평균 조도',
@@ -271,8 +271,8 @@ class _UserPlantDetailScreenState extends State<UserPlantDetailScreen> {
                               ),
                               recommendedLabel: '권장 수분',
                               recommendedValue: formatRange(
-                                _plantDetail?.envStandard.humidity.min,
-                                _plantDetail?.envStandard.humidity.max,
+                                _plantDetail?.envStandard.humidity?.min,
+                                _plantDetail?.envStandard.humidity?.max,
                                 unit: '%',
                               ),
                               averageLabel: '평균 수분',


### PR DESCRIPTION
### Pull Request
상세리포트 접근 오류 & 채팅방 터치 영역 확장

**🪾작업한 브랜치**
- feat/# 15-detail-chatroom

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-FE/issues/15

**🔥 작업 내용**
|문제|수정전|수정후|
|--|--|--|
|상세리포트 접근 오류|<img width="200" alt="Image" src="https://github.com/user-attachments/assets/362a789b-128b-4ee3-b6a1-e93e0f95bbd3" />|<img width="200" alt="image" src="https://github.com/user-attachments/assets/d52bdad0-9935-45b1-9aab-baa8761002e3" />|
|채팅방 터치 영역 확장|<img width="200" alt="Image" src="https://github.com/user-attachments/assets/79166a30-bc3a-444a-b1e1-31b96111a717" />|<img width="200" alt="Image" src="https://github.com/user-attachments/assets/3511f3f6-7761-491a-8c7f-a903fa1b87a3" />|


