### PR TITLE
[Feat] #25 - 식물 도감 상세 페이지 및 검색 기능 추가

### DIFF
--- a/planty/lib/main.dart
+++ b/planty/lib/main.dart
@@ -11,7 +11,7 @@ final RouteObserver<ModalRoute<void>> routeObserver =
     RouteObserver<ModalRoute<void>>();
 
 Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized;
+  WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load();
   await Firebase.initializeApp();
 

--- a/planty/lib/screens/plant/plant_dictionary_detail_screen.dart
+++ b/planty/lib/screens/plant/plant_dictionary_detail_screen.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:planty/constants/colors.dart';
+import 'package:planty/models/plant_info_detail.dart';
+import 'package:planty/services/plant_info_service.dart';
+import 'package:planty/widgets/custom_app_bar.dart';
+import 'package:planty/widgets/detail_info_section.dart';
+
+class PlantDictionaryDetailScreen extends StatefulWidget {
+  final int plantId;
+
+  const PlantDictionaryDetailScreen({super.key, required this.plantId});
+
+  @override
+  State<PlantDictionaryDetailScreen> createState() =>
+      _PlantDictionaryDetailScreenState();
+}
+
+class _PlantDictionaryDetailScreenState
+    extends State<PlantDictionaryDetailScreen> {
+  PlantInfoDetail? _plant;
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchPlantDetail();
+  }
+
+  Future<void> _fetchPlantDetail() async {
+    try {
+      final plant = await PlantInfoService().fetchPlantDetail(widget.plantId);
+      setState(() {
+        _plant = plant;
+        _isLoading = false;
+      });
+    } catch (e) {
+      print('에러 발생: $e');
+      setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(61),
+        child: CustomAppBar(
+          leadingType: AppBarLeadingType.back,
+          titleText: '식물 정보',
+        ),
+      ),
+      body: SafeArea(
+        child:
+            _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : _plant == null
+                ? const Center(child: Text('식물 정보를 불러올 수 없습니다.'))
+                : SingleChildScrollView(
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // 상단: 썸네일 + 이름
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 5,
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(100),
+                              child: Image.network(
+                                _plant!.imageUrl ??
+                                    'https://nongsaro.go.kr/cms_contents/301/12938_MF_ATTACH_01.jpg',
+                                width: 100,
+                                height: 100,
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                            const SizedBox(width: 20),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    _plant!.commonName ?? '',
+                                    style: TextStyle(
+                                      color: AppColors.primary,
+                                      fontWeight: FontWeight.w600,
+                                      fontSize: 15,
+                                    ),
+                                  ),
+                                  Text(
+                                    _plant!.englishName ?? '',
+                                    style: TextStyle(
+                                      color: AppColors.primary,
+                                      fontSize: 11,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Divider(
+                        height: 16,
+                        color: AppColors.primary.withOpacity(0.5),
+                        thickness: 0.5,
+                      ),
+                      const SizedBox(height: 16),
+                      // 큰 이미지
+                      Center(
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(12),
+                          child: Image.network(
+                            _plant!.imageUrl ??
+                                'https://nongsaro.go.kr/cms_contents/301/12938_MF_ATTACH_01.jpg',
+                            width: 300,
+                            height: 300,
+                            fit: BoxFit.cover,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      Divider(
+                        height: 16,
+                        color: AppColors.primary.withOpacity(0.5),
+                        thickness: 0.5,
+                      ),
+                      const SizedBox(height: 16),
+                      // 정보 섹션들
+                      DetailInfoSection(
+                        title: '기본 정보',
+                        infoMap: _plant!.toBasicInfoMap(),
+                      ),
+                      DetailInfoSection(
+                        title: '상세 정보',
+                        infoMap: _plant!.toDetailInfoMap(),
+                      ),
+                      DetailInfoSection(
+                        title: '관리 정보',
+                        infoMap: _plant!.toCareInfoMap(),
+                      ),
+                      DetailInfoSection(
+                        title: '기능성 정보',
+                        infoMap: {'': _plant!.functionalInfo},
+                        showKey: false,
+                      ),
+                    ],
+                  ),
+                ),
+      ),
+    );
+  }
+}

--- a/planty/lib/screens/plant/plant_dictionary_screen.dart
+++ b/planty/lib/screens/plant/plant_dictionary_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:planty/models/plant_info.dart';
+import 'package:planty/screens/plant/plant_dictionary_detail_screen.dart';
 import 'package:planty/services/plant_info_service.dart';
 import 'package:planty/widgets/custom_app_bar.dart';
 import 'package:planty/widgets/custom_bottom_nav_bar.dart';
@@ -57,12 +58,15 @@ class _PlantDictionaryScreenState extends State<PlantDictionaryScreen> {
                       final plant = _plantsList[index];
                       return GestureDetector(
                         onTap: () {
-                          // Navigator.push(
-                          //   context,
-                          //   MaterialPageRoute(
-                          //     builder: (_) => PlantDetailScreen(plantId: plant.id),
-                          //   ),
-                          // );
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder:
+                                  (_) => PlantDictionaryDetailScreen(
+                                    plantId: plant.id!,
+                                  ),
+                            ),
+                          );
                         },
                         child: PlantInfoCard(
                           imageUrl: plant.imageUrl,

--- a/planty/lib/screens/plant/plant_dictionary_screen.dart
+++ b/planty/lib/screens/plant/plant_dictionary_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:planty/constants/colors.dart';
 import 'package:planty/models/plant_info.dart';
 import 'package:planty/screens/plant/plant_dictionary_detail_screen.dart';
 import 'package:planty/services/plant_info_service.dart';
@@ -16,6 +17,7 @@ class PlantDictionaryScreen extends StatefulWidget {
 class _PlantDictionaryScreenState extends State<PlantDictionaryScreen> {
   List<PlantInfo> _plantsList = [];
   bool _isLoading = true;
+  String _searchQuery = '';
 
   @override
   void initState() {
@@ -36,6 +38,15 @@ class _PlantDictionaryScreenState extends State<PlantDictionaryScreen> {
     }
   }
 
+  List<PlantInfo> _filteredPlantList() {
+    if (_searchQuery.isEmpty) return _plantsList;
+    return _plantsList.where((plant) {
+      final query = _searchQuery.toLowerCase();
+      return plant.commonName.toLowerCase().contains(query) ||
+          plant.englishName.toLowerCase().contains(query);
+    }).toList();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -48,36 +59,88 @@ class _PlantDictionaryScreenState extends State<PlantDictionaryScreen> {
         child:
             _isLoading
                 ? const Center(child: CircularProgressIndicator())
-                : _plantsList.isEmpty
-                ? const Center(child: Text('등록 가능한 식물이 없습니다.'))
-                : Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: ListView.builder(
-                    itemCount: _plantsList.length,
-                    itemBuilder: (context, index) {
-                      final plant = _plantsList[index];
-                      return GestureDetector(
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder:
-                                  (_) => PlantDictionaryDetailScreen(
-                                    plantId: plant.id!,
-                                  ),
-                            ),
-                          );
-                        },
-                        child: PlantInfoCard(
-                          imageUrl: plant.imageUrl,
-                          commonName: plant.commonName,
-                          englishName: plant.englishName,
+                : Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          border: Border.all(
+                            color: AppColors.primary,
+                            width: 0.5,
+                          ),
+                          borderRadius: BorderRadius.circular(12),
                         ),
-                      );
-                    },
-                  ),
+                        child: TextField(
+                          decoration: InputDecoration(
+                            hintText: '학명, 키워드로 검색하세요',
+                            hintStyle: TextStyle(
+                              color: AppColors.primary.withOpacity(0.8),
+                              fontSize: 15,
+                            ),
+                            contentPadding: EdgeInsets.symmetric(
+                              vertical: 14,
+                              horizontal: 20,
+                            ),
+                            border: InputBorder.none,
+                            focusedBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: BorderSide(
+                                color: AppColors.primary,
+                                width: 0.6,
+                              ),
+                            ),
+                            suffixIcon: Icon(
+                              Icons.search,
+                              color: AppColors.primary,
+                            ),
+                          ),
+                          onChanged: (value) {
+                            setState(() => _searchQuery = value);
+                          },
+                        ),
+                      ),
+                    ),
+
+                    Expanded(
+                      child:
+                          _filteredPlantList().isEmpty
+                              ? const Center(child: Text('검색 결과가 없습니다.'))
+                              : Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 16,
+                                ),
+                                child: ListView.builder(
+                                  itemCount: _filteredPlantList().length,
+                                  itemBuilder: (context, index) {
+                                    final plant = _filteredPlantList()[index];
+                                    return GestureDetector(
+                                      onTap: () {
+                                        Navigator.push(
+                                          context,
+                                          MaterialPageRoute(
+                                            builder:
+                                                (_) =>
+                                                    PlantDictionaryDetailScreen(
+                                                      plantId: plant.id!,
+                                                    ),
+                                          ),
+                                        );
+                                      },
+                                      child: PlantInfoCard(
+                                        imageUrl: plant.imageUrl,
+                                        commonName: plant.commonName,
+                                        englishName: plant.englishName,
+                                      ),
+                                    );
+                                  },
+                                ),
+                              ),
+                    ),
+                  ],
                 ),
       ),
+
       bottomNavigationBar: CustomBottomNavBar(currentIndex: 1, onTap: (_) {}),
     );
   }

--- a/planty/lib/screens/register_plant/plant_list_screen.dart
+++ b/planty/lib/screens/register_plant/plant_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:planty/constants/colors.dart';
 import 'package:planty/models/plant_info.dart';
 import 'package:planty/screens/register_plant/plant_detail_screen.dart';
 import 'package:planty/services/plant_info_service.dart';
@@ -15,6 +16,7 @@ class PlantListScreen extends StatefulWidget {
 class _PlantListScreenState extends State<PlantListScreen> {
   List<PlantInfo> _plantsList = [];
   bool _isLoading = true;
+  String _searchQuery = '';
 
   @override
   void initState() {
@@ -35,6 +37,15 @@ class _PlantListScreenState extends State<PlantListScreen> {
     }
   }
 
+  List<PlantInfo> _filteredPlantList() {
+    if (_searchQuery.isEmpty) return _plantsList;
+    return _plantsList.where((plant) {
+      final query = _searchQuery.toLowerCase();
+      return plant.commonName.toLowerCase().contains(query) ||
+          plant.englishName.toLowerCase().contains(query);
+    }).toList();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -50,33 +61,77 @@ class _PlantListScreenState extends State<PlantListScreen> {
         child:
             _isLoading
                 ? const Center(child: CircularProgressIndicator())
-                : _plantsList.isEmpty
-                ? const Center(child: Text('등록 가능한 식물이 없습니다.'))
-                : Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: ListView.builder(
-                    itemCount: _plantsList.length,
-                    itemBuilder: (context, index) {
-                      final plant = _plantsList[index];
-                      return GestureDetector(
-                        onTap: () {
-                          print('눌린 식물 ID: ${plant.id}');
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder:
-                                  (_) => PlantDetailScreen(plantId: plant.id),
-                            ),
-                          );
-                        },
-                        child: PlantInfoCard(
-                          imageUrl: plant.imageUrl,
-                          commonName: plant.commonName,
-                          englishName: plant.englishName,
+                : Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          border: Border.all(
+                            color: AppColors.primary,
+                            width: 0.5,
+                          ),
+                          borderRadius: BorderRadius.circular(12),
                         ),
-                      );
-                    },
-                  ),
+                        child: TextField(
+                          decoration: InputDecoration(
+                            hintText: '학명, 키워드로 검색하세요',
+                            hintStyle: TextStyle(
+                              color: AppColors.primary.withOpacity(0.8),
+                              fontSize: 15,
+                            ),
+                            contentPadding: const EdgeInsets.symmetric(
+                              vertical: 14,
+                              horizontal: 20,
+                            ),
+                            border: InputBorder.none,
+                            suffixIcon: Icon(
+                              Icons.search,
+                              color: AppColors.primary,
+                            ),
+                          ),
+                          onChanged: (value) {
+                            setState(() => _searchQuery = value);
+                          },
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child:
+                          _filteredPlantList().isEmpty
+                              ? const Center(child: Text('검색 결과가 없습니다.'))
+                              : Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 16,
+                                ),
+                                child: ListView.builder(
+                                  itemCount: _filteredPlantList().length,
+                                  itemBuilder: (context, index) {
+                                    final plant = _filteredPlantList()[index];
+                                    return GestureDetector(
+                                      onTap: () {
+                                        print('눌린 식물 ID: ${plant.id}');
+                                        Navigator.push(
+                                          context,
+                                          MaterialPageRoute(
+                                            builder:
+                                                (_) => PlantDetailScreen(
+                                                  plantId: plant.id,
+                                                ),
+                                          ),
+                                        );
+                                      },
+                                      child: PlantInfoCard(
+                                        imageUrl: plant.imageUrl,
+                                        commonName: plant.commonName,
+                                        englishName: plant.englishName,
+                                      ),
+                                    );
+                                  },
+                                ),
+                              ),
+                    ),
+                  ],
                 ),
       ),
     );


### PR DESCRIPTION
### Pull Request
식물 도감 상세 페이지 및 검색 기능 추가

**🪾작업한 브랜치**
- feat/# 25-dictionary

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-FE/issues/25

**🔥 작업 내용**
- 식물 도감 상세 페이지 UI 구현 및 연결
- 식물 도감, 식물 등록 화면에 검색창 추가

|기능|화면|
|--|--|
|식명 검색|<img src="https://github.com/user-attachments/assets/5d156988-88de-4c73-ba2f-9245527d8861" width="250px">|
|상세 페이지 연결|<img src="https://github.com/user-attachments/assets/bed54d2d-5508-4b73-8c73-6583e84a3018" width="250px">|

