### PR TITLE
[Feat] #27 - 식물 상태 및 자동제어 관련 FCM 알림 수신 처리 및 알림 UI 구현

### DIFF
--- a/planty/android/app/src/main/AndroidManifest.xml
+++ b/planty/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
     package="com.example.planty"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <application
         android:label="planty"
         android:name="${applicationName}"

--- a/planty/lib/main.dart
+++ b/planty/lib/main.dart
@@ -1,19 +1,80 @@
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:planty/screens/chat/chat_list_screen.dart';
 import 'package:planty/screens/home/home_screen.dart';
 import 'package:planty/screens/my/my_screen.dart';
 import 'package:planty/screens/plant/plant_dictionary_screen.dart';
 import 'package:planty/screens/onboarding/splash_screen.dart';
+import 'package:planty/services/fcm_service.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 final RouteObserver<ModalRoute<void>> routeObserver =
     RouteObserver<ModalRoute<void>>();
+final fcmService = FcmService();
+
+@pragma('vm:entry-point')
+Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  await Firebase.initializeApp();
+
+  final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
+      FlutterLocalNotificationsPlugin();
+
+  const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+  const settings = InitializationSettings(android: android);
+  await flutterLocalNotificationsPlugin.initialize(settings);
+
+  final notificationDetails = NotificationDetails(
+    android: AndroidNotificationDetails(
+      'planty_channel',
+      'Planty 알림',
+      importance: Importance.max,
+      priority: Priority.high,
+      icon: '@mipmap/ic_launcher',
+      color: Colors.white,
+    ),
+  );
+
+  final title = message.data['title'] ?? '알림';
+  final body = message.data['body'] ?? '내용 없음';
+
+  await flutterLocalNotificationsPlugin.show(
+    title.hashCode,
+    title,
+    body,
+    notificationDetails,
+  );
+}
+
+Future<void> requestNotificationPermission() async {
+  final status = await Permission.notification.status;
+  if (status.isDenied || status.isRestricted) {
+    await Permission.notification.request();
+  }
+}
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
+
   await dotenv.load();
   await Firebase.initializeApp();
+  await requestNotificationPermission();
+  await fcmService.initLocalNotification();
+
+  FirebaseMessaging.instance.onTokenRefresh.listen((newToken) {
+    print("FCM 토큰 갱신됨: $newToken");
+    fcmService.sendDeviceTokenToServer(newToken);
+  });
+
+  FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+    print("📥 FCM 수신됨");
+    final title = message.data['title'];
+    final body = message.data['body'];
+    fcmService.showNotification(RemoteNotification(title: title, body: body));
+  });
 
   runApp(const MyApp());
 }

--- a/planty/lib/models/notification_response.dart
+++ b/planty/lib/models/notification_response.dart
@@ -1,0 +1,31 @@
+class NotificationResponse {
+  final int id;
+  final String title;
+  final String body;
+  final bool isRead;
+  final DateTime receivedAt;
+  final String plantNickname;
+  final String plantImageUrl;
+
+  NotificationResponse({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.isRead,
+    required this.receivedAt,
+    required this.plantNickname,
+    required this.plantImageUrl,
+  });
+
+  factory NotificationResponse.fromJson(Map<String, dynamic> json) {
+    return NotificationResponse(
+      id: json['id'],
+      title: json['title'],
+      body: json['body'],
+      isRead: json['read'],
+      receivedAt: DateTime.parse(json['receivedAt']),
+      plantNickname: json['plantNickname'] ?? '',
+      plantImageUrl: json['plantImageUrl'] ?? '',
+    );
+  }
+}

--- a/planty/lib/screens/chat/chat_list_screen.dart
+++ b/planty/lib/screens/chat/chat_list_screen.dart
@@ -139,7 +139,7 @@ class _ChatListScreenState extends State<ChatListScreen> with RouteAware {
       backgroundColor: Colors.white,
       appBar: PreferredSize(
         preferredSize: Size.fromHeight(61),
-        child: CustomAppBar(trailingType: AppBarTrailingType.notification),
+        child: CustomAppBar(),
       ),
       body: SafeArea(
         child: Column(

--- a/planty/lib/screens/home/notification_screen.dart
+++ b/planty/lib/screens/home/notification_screen.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:planty/models/notification_response.dart';
+import 'package:planty/services/notification_service.dart';
+import 'package:planty/widgets/custom_app_bar.dart';
+
+class NotificationScreen extends StatefulWidget {
+  const NotificationScreen({super.key});
+
+  @override
+  State<NotificationScreen> createState() => _NotificationScreenState();
+}
+
+class _NotificationScreenState extends State<NotificationScreen> {
+  late Future<List<NotificationResponse>> _notifications;
+
+  @override
+  void initState() {
+    super.initState();
+    _notifications = NotificationService().fetchNotificationsFromJwt();
+  }
+
+  String formatTime(DateTime time) {
+    final now = DateTime.now();
+    final diff = now.difference(time);
+    if (diff.inMinutes < 1) return '방금 전';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}분 전';
+    if (diff.inHours < 24) return '${diff.inHours}시간 전';
+    return '${time.month}/${time.day} ${time.hour}:${time.minute.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (!didPop) {
+          Navigator.pop(context, true);
+        }
+      },
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(61),
+          child: CustomAppBar(
+            leadingType: AppBarLeadingType.back,
+            titleText: '알림',
+            onBackTap: () async {
+              await NotificationService().markAllAsRead();
+              final updated =
+                  await NotificationService().fetchNotificationsFromJwt();
+              final allRead = updated.every((noti) => noti.isRead);
+
+              if (!mounted) return;
+
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                Navigator.pop(context, allRead);
+              });
+            },
+          ),
+        ),
+
+        backgroundColor: Colors.white,
+        body: FutureBuilder<List<NotificationResponse>>(
+          future: _notifications,
+          builder: (context, snapshot) {
+            if (!snapshot.hasData) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            final notifications = snapshot.data!;
+            if (notifications.isEmpty) {
+              return const Center(child: Text('새로운 알림이 없습니다.'));
+            }
+            return ListView.builder(
+              itemCount: notifications.length,
+              itemBuilder: (context, index) {
+                final noti = notifications[index];
+                return Container(
+                  color: noti.isRead ? Colors.white : const Color(0xFFF0F4F8),
+                  child: ListTile(
+                    leading:
+                        noti.plantImageUrl.isNotEmpty
+                            ? CircleAvatar(
+                              backgroundImage: NetworkImage(noti.plantImageUrl),
+                              backgroundColor: Colors.transparent,
+                            )
+                            : const CircleAvatar(
+                              child: Icon(Icons.local_florist),
+                            ),
+                    title: Text(
+                      noti.title,
+                      style: TextStyle(
+                        fontWeight:
+                            noti.isRead ? FontWeight.normal : FontWeight.bold,
+                      ),
+                    ),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(noti.body),
+                        const SizedBox(height: 4),
+                        Text(
+                          '${noti.plantNickname} • ${formatTime(noti.receivedAt)}',
+                          style: const TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/planty/lib/screens/home/user_plant_detail_screen.dart
+++ b/planty/lib/screens/home/user_plant_detail_screen.dart
@@ -400,18 +400,18 @@ class _UserPlantDetailScreenState extends State<UserPlantDetailScreen> {
                               label: '환경 조도',
                               value: formatValue(
                                 _plantDetail?.sensorData?.light,
-                                unit: '',
+                                unit: 'Lux',
                               ),
                               recommendedLabel: '권장 조도',
                               recommendedValue: formatRange(
                                 _plantDetail?.envStandard.light?.min,
                                 _plantDetail?.envStandard.light?.max,
-                                unit: '',
+                                unit: 'Lux',
                               ),
                               averageLabel: '평균 조도',
                               averageValue: formatValue(
                                 _plantDetail?.status?.lightScore,
-                                unit: '',
+                                unit: 'Lux',
                               ),
                             ),
                             EnvCard(
@@ -419,18 +419,18 @@ class _UserPlantDetailScreenState extends State<UserPlantDetailScreen> {
                               label: '흙 수분',
                               value: formatValue(
                                 _plantDetail?.sensorData?.humidity,
-                                unit: '',
+                                unit: '%',
                               ),
                               recommendedLabel: '권장 수분',
                               recommendedValue: formatRange(
                                 _plantDetail?.envStandard.humidity?.min,
                                 _plantDetail?.envStandard.humidity?.max,
-                                unit: '',
+                                unit: '%',
                               ),
                               averageLabel: '평균 수분',
                               averageValue: formatValue(
                                 _plantDetail?.status?.humidityScore,
-                                unit: '',
+                                unit: '%',
                               ),
                             ),
                           ],

--- a/planty/lib/screens/plant/plant_dictionary_screen.dart
+++ b/planty/lib/screens/plant/plant_dictionary_screen.dart
@@ -53,7 +53,7 @@ class _PlantDictionaryScreenState extends State<PlantDictionaryScreen> {
       backgroundColor: Colors.white,
       appBar: PreferredSize(
         preferredSize: Size.fromHeight(61),
-        child: CustomAppBar(trailingType: AppBarTrailingType.notification),
+        child: CustomAppBar(),
       ),
       body: SafeArea(
         child:

--- a/planty/lib/services/fcm_service.dart
+++ b/planty/lib/services/fcm_service.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:http/http.dart' as http;
 
 class FcmService {
@@ -28,5 +30,31 @@ class FcmService {
     } else {
       print("전송 실패: ${response.statusCode} ${response.body}");
     }
+  }
+
+  final FlutterLocalNotificationsPlugin _localPlugin =
+      FlutterLocalNotificationsPlugin();
+  Future<void> initLocalNotification() async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const settings = InitializationSettings(android: android);
+    await _localPlugin.initialize(settings);
+  }
+
+  Future<void> showNotification(RemoteNotification notification) async {
+    const androidDetails = AndroidNotificationDetails(
+      'planty_channel',
+      'Planty 알림',
+      importance: Importance.max,
+      priority: Priority.high,
+      icon: '@mipmap/ic_launcher',
+      color: Colors.white,
+    );
+    const notificationDetails = NotificationDetails(android: androidDetails);
+    await _localPlugin.show(
+      notification.hashCode,
+      notification.title,
+      notification.body,
+      notificationDetails,
+    );
   }
 }

--- a/planty/lib/services/notification_service.dart
+++ b/planty/lib/services/notification_service.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:planty/models/notification_response.dart';
+import 'package:http/http.dart' as http;
+
+class NotificationService {
+  final _storage = FlutterSecureStorage();
+  final _baseUrl = dotenv.env['BASE_URL']!;
+
+  Future<List<NotificationResponse>> fetchNotificationsFromJwt() async {
+    final token = await _storage.read(key: 'token');
+    if (token == null) throw Exception('토큰 없음');
+
+    final response = await http.get(
+      Uri.parse('$_baseUrl/notifications/me'),
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      final List data = jsonDecode(utf8.decode(response.bodyBytes));
+      return data.map((e) => NotificationResponse.fromJson(e)).toList();
+    } else {
+      throw Exception('알림 목록 불러오기 실패');
+    }
+  }
+
+  Future<void> markAllAsRead() async {
+    final token = await _storage.read(key: 'token');
+    if (token == null) throw Exception('토큰 없음');
+
+    final response = await http.patch(
+      Uri.parse('$_baseUrl/notifications/me/read-all'),
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('전체 알림 읽음 처리 실패');
+    }
+  }
+}

--- a/planty/lib/widgets/custom_app_bar.dart
+++ b/planty/lib/widgets/custom_app_bar.dart
@@ -10,6 +10,9 @@ class CustomAppBar extends StatelessWidget {
   final String? titleText;
   final AppBarTrailingType trailingType;
   final Widget? customTrailingWidget;
+  final bool showUnreadDot;
+  final VoidCallback? onNotificationTap;
+  final VoidCallback? onBackTap;
 
   const CustomAppBar({
     super.key,
@@ -17,6 +20,9 @@ class CustomAppBar extends StatelessWidget {
     this.titleText,
     this.trailingType = AppBarTrailingType.none,
     this.customTrailingWidget,
+    this.showUnreadDot = false,
+    this.onNotificationTap,
+    this.onBackTap,
   });
 
   @override
@@ -32,7 +38,7 @@ class CustomAppBar extends StatelessWidget {
         break;
       case AppBarLeadingType.back:
         leadingWidget = IconButton(
-          onPressed: () => Navigator.pop(context),
+          onPressed: onBackTap ?? () => Navigator.pop(context),
           icon: Icon(Icons.arrow_back_ios, color: AppColors.primary),
         );
         break;
@@ -45,11 +51,32 @@ class CustomAppBar extends StatelessWidget {
     Widget trailingWidget;
     switch (trailingType) {
       case AppBarTrailingType.notification:
-        trailingWidget = Icon(
-          Icons.notifications_outlined,
-          color: AppColors.primary,
+        trailingWidget = Stack(
+          children: [
+            IconButton(
+              icon: Icon(
+                Icons.notifications_outlined,
+                color: AppColors.primary,
+              ),
+              onPressed: onNotificationTap,
+            ),
+            if (showUnreadDot)
+              Positioned(
+                right: 6,
+                top: 6,
+                child: Container(
+                  width: 8,
+                  height: 8,
+                  decoration: const BoxDecoration(
+                    color: Colors.red,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+              ),
+          ],
         );
         break;
+
       case AppBarTrailingType.menu:
         trailingWidget =
             customTrailingWidget ??

--- a/planty/lib/widgets/env_card.dart
+++ b/planty/lib/widgets/env_card.dart
@@ -48,22 +48,29 @@ class EnvCard extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(width: 5),
-                Column(
-                  children: [
-                    Text(
-                      label,
-                      style: TextStyle(fontSize: 8, color: AppColors.primary),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      value,
-                      style: TextStyle(
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.primary,
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        label,
+                        style: TextStyle(fontSize: 8, color: AppColors.primary),
                       ),
-                    ),
-                  ],
+                      const SizedBox(height: 4),
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          value,
+                          style: TextStyle(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.primary,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ],
             ),

--- a/planty/lib/widgets/plant_status_btn.dart
+++ b/planty/lib/widgets/plant_status_btn.dart
@@ -121,7 +121,11 @@ class _PlantStatusBtnState extends State<PlantStatusBtn>
           type: widget.commandType,
         );
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('${_getActionLabel(widget.commandType)} 시작!')),
+          SnackBar(
+            content: Text(
+              '${_getActionLabel(widget.commandType)} 시작! 상태 반영까지 잠시 걸릴 수 있어요.',
+            ),
+          ),
         );
       } catch (e) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/planty/pubspec.lock
+++ b/planty/pubspec.lock
@@ -536,6 +536,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.4.0"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.1.0"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.7"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/planty/pubspec.yaml
+++ b/planty/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   firebase_messaging: ^15.2.6
   flutter_local_notifications: ^19.2.1
   firebase_core: ^3.13.1
+  permission_handler: ^11.0.0
 
 dev_dependencies:
   flutter_test:

--- a/planty/windows/flutter/generated_plugin_registrant.cc
+++ b/planty/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <permission_handler_windows/permission_handler_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSelectorWindowsRegisterWithRegistrar(
@@ -17,4 +18,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  PermissionHandlerWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
 }

--- a/planty/windows/flutter/generated_plugins.cmake
+++ b/planty/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   firebase_core
   flutter_secure_storage_windows
+  permission_handler_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
### Pull Request
식물 상태 및 자동제어 관련 FCM 알림 수신 처리 및 알림 UI 구현

**🪾작업한 브랜치**
- feat/# 27-fcm-notification-ui

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-FE/issues/27
- https://github.com/Team-BIoTy/Planty-BE/issues/25

**🔥 작업 내용**
- Firebase Messaging 연동: 포그라운드 및 백그라운드 푸시 알림 수신 처리
- 수신된 알림 LocalNotification으로 즉시 표시
- 푸시 알림 데이터 저장 및 알림 목록 화면 구현
- 홈 화면 상단바에 읽지 않은 알림 존재 시 빨간 점 표시
- 알림 목록 UI에서 읽음 여부에 따른 스타일 처리
- 홈 외 화면에서는 상단바 알림 아이콘 제거 (디자인 정리)
- 명령 실행 후 상태 반영이 지연될 수 있다는 스낵바 안내 메시지 추가 (UX 개선)
- EnvCard에서 Lux 단위 텍스트 넘침 문제 해결 (UI 개선)

|기능|화면|
|--|--|
|백그라운드 알림|<img src="https://github.com/user-attachments/assets/d27712b7-4af7-440e-a7ad-a1b33eef5e03" width="250px">|
|알림 목록 화면|<img src="https://github.com/user-attachments/assets/544d24d4-8627-44cf-a867-e069e60c9ff8" width="250px">|
