### PR TITLE
[Feat] #30 - 챗봇 요청에 plant_info 추가

### DIFF
--- a/planty/lib/models/chat_room_detail.dart
+++ b/planty/lib/models/chat_room_detail.dart
@@ -1,4 +1,5 @@
 import 'package:planty/models/chat_message.dart';
+import 'package:planty/models/plant_info_detail.dart';
 
 class ChatRoomDetail {
   final int chatRoomId;
@@ -11,6 +12,7 @@ class ChatRoomDetail {
   final int? sensorLogId;
   final int? plantEnvStandardsId;
   final List<ChatMessage> messages;
+  final PlantInfoDetail? plantInfoDetail;
 
   ChatRoomDetail({
     required this.chatRoomId,
@@ -23,6 +25,7 @@ class ChatRoomDetail {
     this.sensorLogId,
     this.plantEnvStandardsId,
     required this.messages,
+    this.plantInfoDetail,
   });
 
   factory ChatRoomDetail.fromJson(Map<String, dynamic> json) {
@@ -40,6 +43,10 @@ class ChatRoomDetail {
           (json['messages'] as List)
               .map((e) => ChatMessage.fromJson(e))
               .toList(),
+      plantInfoDetail:
+          json['plantInfo'] != null
+              ? PlantInfoDetail.fromJson(json['plantInfo'])
+              : null,
     );
   }
 }

--- a/planty/lib/models/plant_info_detail.dart
+++ b/planty/lib/models/plant_info_detail.dart
@@ -196,6 +196,52 @@ class PlantInfoDetail {
     };
   }
 
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'imageUrl': imageUrl,
+      'commonName': commonName,
+      'scientificName': scientificName,
+      'englishName': englishName,
+      'tradeName': tradeName,
+      'familyName': familyName,
+      'origin': origin,
+      'careTip': careTip,
+      'category': category,
+      'growthForm': growthForm,
+      'growthHeight': growthHeight,
+      'growthWidth': growthWidth,
+      'indoorGardenUse': indoorGardenUse,
+      'ecologicalType': ecologicalType,
+      'leafShape': leafShape,
+      'leafPattern': leafPattern,
+      'leafColor': leafColor,
+      'floweringSeason': floweringSeason,
+      'flowerColor': flowerColor,
+      'fruitingSeason': fruitingSeason,
+      'fruitColor': fruitColor,
+      'fragrance': fragrance,
+      'propagationMethod': propagationMethod,
+      'propagationSeason': propagationSeason,
+      'careLevel': careLevel,
+      'careDifficulty': careDifficulty,
+      'lightRequirement': lightRequirement,
+      'placement': placement,
+      'growthRate': growthRate,
+      'optimalTemperature': optimalTemperature,
+      'minWinterTemperature': minWinterTemperature,
+      'humidity': humidity,
+      'fertilizer': fertilizer,
+      'soilType': soilType,
+      'wateringSpring': wateringSpring,
+      'wateringSummer': wateringSummer,
+      'wateringAutumn': wateringAutumn,
+      'wateringWinter': wateringWinter,
+      'pestsDiseases': pestsDiseases,
+      'functionalInfo': functionalInfo,
+    };
+  }
+
   // 기능성 정보
   Map<String, String?> toFunctionInfoMap() {
     return {'기능성 정보': functionalInfo};

--- a/planty/lib/screens/chat/chat_screen.dart
+++ b/planty/lib/screens/chat/chat_screen.dart
@@ -66,6 +66,7 @@ class _ChatScreenState extends State<ChatScreen> {
         sensorLogId: _chatRoomDetail!.sensorLogId!,
         plantEnvStandardsId: _chatRoomDetail!.plantEnvStandardsId!,
         persona: _chatRoomDetail!.personalityLabel!,
+        plantInfo: _chatRoomDetail!.plantInfoDetail?.toJson(),
       );
       setState(() {
         _chatRoomDetail?.messages.add(response);

--- a/planty/lib/services/chat_service.dart
+++ b/planty/lib/services/chat_service.dart
@@ -78,6 +78,7 @@ class ChatService {
     required int sensorLogId,
     required int plantEnvStandardsId,
     required String persona,
+    required Map<String, dynamic>? plantInfo,
   }) async {
     final token = await _storage.read(key: 'token');
     final response = await http.post(
@@ -91,6 +92,7 @@ class ChatService {
         'sensorLogId': sensorLogId,
         'plantEnvStandardsId': plantEnvStandardsId,
         'persona': persona,
+        'plantInfo': plantInfo,
       }),
     );
 


### PR DESCRIPTION
### Pull Request
챗봇 메시지 전송 시 식물 정보 알 수 있도록 plant_info_detail 데이터 추가

**🪾작업한 브랜치**
- feat/# 30-chat-plantinfo

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-FE/issues/30
- https://github.com/Team-BIoTy/Planty-BE/issues/28