### PR TITLE
[Fix] #35 - 챗봇 SLM/LLM 선택 가능하도록 API 연동 코드 및 UI 수정

### DIFF
--- a/planty/lib/screens/chat/chat_screen.dart
+++ b/planty/lib/screens/chat/chat_screen.dart
@@ -29,6 +29,7 @@ class _ChatScreenState extends State<ChatScreen> {
   final ScrollController _scrollController = ScrollController();
   bool _isLoading = true;
   bool _isBotTyping = false;
+  String _selectedType = 'llm';
 
   @override
   void initState() {
@@ -106,10 +107,12 @@ class _ChatScreenState extends State<ChatScreen> {
                 plantEnvStandardsId: _chatRoomDetail!.plantEnvStandardsId!,
                 persona: _chatRoomDetail!.personalityLabel!,
                 plantInfo: _chatRoomDetail!.plantInfoDetail?.toJson(),
+                type: _selectedType,
               )
               : await ChatService().sendQaMessage(
                 chatRoomId: widget.chatRoomId,
                 message: content,
+                type: _selectedType,
               );
 
       setState(() {
@@ -214,6 +217,26 @@ class _ChatScreenState extends State<ChatScreen> {
                             );
                           },
                         ),
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text("모델 선택: "),
+                  DropdownButton<String>(
+                    value: _selectedType,
+                    items: const [
+                      DropdownMenuItem(value: 'slm', child: Text('SLM')),
+                      DropdownMenuItem(value: 'llm', child: Text('LLM')),
+                    ],
+                    onChanged: (value) {
+                      if (value != null) {
+                        setState(() {
+                          _selectedType = value;
+                        });
+                      }
+                    },
+                  ),
+                ],
               ),
               Container(
                 color: Colors.white,

--- a/planty/lib/screens/chat/chat_screen.dart
+++ b/planty/lib/screens/chat/chat_screen.dart
@@ -218,31 +218,17 @@ class _ChatScreenState extends State<ChatScreen> {
                           },
                         ),
               ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text("모델 선택: "),
-                  DropdownButton<String>(
-                    value: _selectedType,
-                    items: const [
-                      DropdownMenuItem(value: 'slm', child: Text('SLM')),
-                      DropdownMenuItem(value: 'llm', child: Text('LLM')),
-                    ],
-                    onChanged: (value) {
-                      if (value != null) {
-                        setState(() {
-                          _selectedType = value;
-                        });
-                      }
-                    },
-                  ),
-                ],
-              ),
               Container(
                 color: Colors.white,
                 child: ChatInputField(
                   controller: _controller,
                   onSend: _sendMessage,
+                  selectedType: _selectedType,
+                  onTypeChanged: (value) {
+                    setState(() {
+                      _selectedType = value;
+                    });
+                  },
                 ),
               ),
             ],

--- a/planty/lib/services/chat_service.dart
+++ b/planty/lib/services/chat_service.dart
@@ -79,6 +79,7 @@ class ChatService {
     required int plantEnvStandardsId,
     required String persona,
     required Map<String, dynamic>? plantInfo,
+    required String type,
   }) async {
     final token = await _storage.read(key: 'token');
     final response = await http.post(
@@ -93,6 +94,7 @@ class ChatService {
         'plantEnvStandardsId': plantEnvStandardsId,
         'persona': persona,
         'plantInfo': plantInfo,
+        'type': type,
       }),
     );
 
@@ -107,6 +109,7 @@ class ChatService {
   Future<ChatMessage> sendQaMessage({
     required int chatRoomId,
     required String message,
+    required String type,
   }) async {
     final token = await _storage.read(key: 'token');
     if (token == null) throw Exception('토큰 없음');
@@ -117,7 +120,11 @@ class ChatService {
         'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
-      body: jsonEncode({'chatRoomId': chatRoomId, 'userInput': message}),
+      body: jsonEncode({
+        'chatRoomId': chatRoomId,
+        'userInput': message,
+        'type': type,
+      }),
     );
 
     if (response.statusCode == 200) {

--- a/planty/lib/widgets/chat_input_field.dart
+++ b/planty/lib/widgets/chat_input_field.dart
@@ -37,6 +37,38 @@ class ChatInputField extends StatelessWidget {
                     hintStyle: TextStyle(color: AppColors.grey3, fontSize: 14),
                     hoverColor: AppColors.primary,
                     prefixIcon: GestureDetector(
+                      onTap: () {
+                        final nextType = selectedType == "slm" ? "llm" : "slm";
+                        onTypeChanged(nextType);
+                      },
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          SizedBox(width: 8),
+                          Icon(
+                            selectedType == "llm"
+                                ? Icons.bolt
+                                : Icons.auto_awesome,
+                            color: AppColors.primary,
+                            size: 18,
+                          ),
+                          SizedBox(width: 4),
+                          Text(
+                            selectedType.toUpperCase(),
+                            style: TextStyle(
+                              color: AppColors.primary,
+                              fontSize: 12,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          SizedBox(width: 6),
+                        ],
+                      ),
+                    ),
+                    prefixIconConstraints: BoxConstraints(
+                      minWidth: 0,
+                      minHeight: 0,
+                    ),
                   ),
                   style: TextStyle(fontSize: 14),
                   cursorColor: AppColors.primary,

--- a/planty/lib/widgets/chat_input_field.dart
+++ b/planty/lib/widgets/chat_input_field.dart
@@ -4,11 +4,15 @@ import 'package:planty/constants/colors.dart';
 class ChatInputField extends StatelessWidget {
   final TextEditingController controller;
   final void Function(String) onSend;
+  final String selectedType;
+  final void Function(String) onTypeChanged;
 
   const ChatInputField({
     super.key,
     required this.controller,
     required this.onSend,
+    required this.selectedType,
+    required this.onTypeChanged,
   });
 
   @override
@@ -20,7 +24,6 @@ class ChatInputField extends StatelessWidget {
           children: [
             Expanded(
               child: Container(
-                padding: EdgeInsets.symmetric(horizontal: 16),
                 decoration: BoxDecoration(
                   color: Colors.white,
                   borderRadius: BorderRadius.circular(25),
@@ -33,6 +36,7 @@ class ChatInputField extends StatelessWidget {
                     hintText: '메시지를 입력하세요...',
                     hintStyle: TextStyle(color: AppColors.grey3, fontSize: 14),
                     hoverColor: AppColors.primary,
+                    prefixIcon: GestureDetector(
                   ),
                   style: TextStyle(fontSize: 14),
                   cursorColor: AppColors.primary,


### PR DESCRIPTION
### Pull Request
챗봇 SLM/LLM 선택 가능하도록 API 연동 코드 및 UI 수정

**🪾작업한 브랜치**
- fix/# 35-chatbot-select

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-FE/issues/35
- https://github.com/Team-BIoTy/Planty-BE/issues/35

**🔥 작업 내용**
- 챗봇 api 수정에 따른 코드 반영 (type 받도록)
- 디폴트는 llm 요청으로 설정
- 챗봇 입력창 왼쪽에 토글 버튼 추가하여 slm, llm 선택 가능하도록 ui 수정

|기능|화면|
|--|--|
|slm/llm 선택 버튼 추가|<img src="https://github.com/user-attachments/assets/83d1ed11-79c7-47ca-9622-4b9133af6453" width="250px"><img src="https://github.com/user-attachments/assets/e0388112-f765-4982-a933-25429cc0e197" width="250px">|

